### PR TITLE
default: add example for flake module options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ Using flake, installing `nix-flatpak` as a NixOs module would looks something li
 
 ```
 
+
+### Remotes
+
+By default `nix-flatpak` will add the flathub remote. Remotes can be manually
+configured via the `services.flatpak.remotes` option:
+
+```nix
+[{ name = "flathub-beta"; location = "https://flathub.org/beta-repo/flathub-beta.flatpakrepo"; }]
+```
+
+### Packages
 Declare packages to install with:
 ```nix
   services.flatpak.packages = [

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -18,6 +18,7 @@ let
       args = mkOption {
         type = types.nullOr types.str;
         description = "Extra arguments to pass to flatpak remote-add";
+        example = [ "--verbose" ];
         default = null;
       };
     };
@@ -53,12 +54,26 @@ in
     description = mkDoc ''
       Declares a list of applications to install.
     '';
+    example = literalExpression ''
+        [
+            # declare applications to install using its fqdn
+            "com.obsproject.Studio"
+            # specify a remote.
+            { appId = "com.brave.Browser"; origin = "flathub";  }
+            # Pin the application to a specific commit.
+            { appId = "im.riot.Riot"; commit = "bdcc7fff8359d927f25226eae8389210dba3789ca5d06042d6c9c133e6b1ceb1" }
+        ];
+    '';
   };
   remotes = mkOption {
     type = with types; listOf (coercedTo str (name: { inherit name location; }) (submodule remoteOptions));
     default = [{ name = "flathub"; location = "https://dl.flathub.org/repo/flathub.flatpakrepo"; }];
     description = mkDoc ''
       Declare a list of flatpak repositories.
+    '';
+    example = literalExpression ''
+        # Flathub is the default initialized by this flake.
+        [{ name = "flathub"; location = "https://dl.flathub.org/repo/flathub.flatpakrepo"; }]
     '';
   };
 


### PR DESCRIPTION
Add usage examples for the module public API.
Add documentation for the `services.flatpak.remotes` option.