### PR TITLE
Add options to update installed applications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,27 @@ You can pin a specific commit setting `commit=<hash>` attribute.
 
 Rebuild your system (or home-manager) for changes to take place.
 
+### Updates
+
+Set
+```nix
+services.flatpak.update.onActivation = true;
+```
+to enable updates at system activation. The default is `false`
+so that repeated invocations of `nixos-rebuild switch` are idempotent. Applications 
+pinned to a specific commit hash will not be updated.
+
+Periodic updates can be enabled  by setting:
+```nix
+services.flatpak.update = {
+  auto = {
+    enable = true;
+    onCalendar = "weekly"; # Default value
+  };
+};
+```
+Auto updates trigger on system activation.
+
+Under the hood, updates are scheduled by realtime systemd timers. `onCalendar` accepts systemd's
+`update.auto.OnCalendar` expressions. Timers are persisted across sleep / resume cycles.
+See https://wiki.archlinux.org/title/systemd/Timers for more information. 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -55,14 +55,14 @@ in
       Declares a list of applications to install.
     '';
     example = literalExpression ''
-        [
-            # declare applications to install using its fqdn
-            "com.obsproject.Studio"
-            # specify a remote.
-            { appId = "com.brave.Browser"; origin = "flathub";  }
-            # Pin the application to a specific commit.
-            { appId = "im.riot.Riot"; commit = "bdcc7fff8359d927f25226eae8389210dba3789ca5d06042d6c9c133e6b1ceb1" }
-        ];
+      [
+          # declare applications to install using its fqdn
+          "com.obsproject.Studio"
+          # specify a remote.
+          { appId = "com.brave.Browser"; origin = "flathub";  }
+          # Pin the application to a specific commit.
+          { appId = "im.riot.Riot"; commit = "bdcc7fff8359d927f25226eae8389210dba3789ca5d06042d6c9c133e6b1ceb1" }
+      ];
     '';
   };
   remotes = mkOption {
@@ -72,8 +72,19 @@ in
       Declare a list of flatpak repositories.
     '';
     example = literalExpression ''
-        # Flathub is the default initialized by this flake.
-        [{ name = "flathub"; location = "https://dl.flathub.org/repo/flathub.flatpakrepo"; }]
+      # Flathub is the default initialized by this flake.
+      [{ name = "flathub"; location = "https://dl.flathub.org/repo/flathub.flatpakrepo"; }]
+    '';
+  };
+  update = mkOption {
+    type = types.bool;
+    default = false;
+    description = lib.mdDoc ''
+      Whether to enable flatpak to upgrade applications during
+      {command}`nixos` system activation. The default is `false`
+      so that repeated invocations of {command}`nixos-rebuild switch` are idempotent.
+
+      implementation: appends --or-update to each flatpak install command.
     '';
   };
 

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -45,6 +45,50 @@ let
     };
   };
 
+  updateOptions = { cfg, ... }: {
+    options = {
+      onActivation = mkOption {
+        type = types.bool;
+        default = false;
+        description = lib.mdDoc ''
+          Whether to enable flatpak to upgrade applications during
+          {command}`nixos` system activation. The default is `false`
+          so that repeated invocations of {command}`nixos-rebuild switch` are idempotent.
+
+          implementation: appends --or-update to each flatpak install command.
+        '';
+      };
+      auto = mkOption {
+        type = with types; submodule ({ cfg, ... }: {
+          options = {
+            enable = mkOption {
+              type = types.bool;
+              default = false;
+              description = lib.mdDoc ''
+                Whether to enable flatpak to upgrade applications during
+                {command}`nixos` system activation, and scheudle periodic updates
+                afterwards.
+
+                implementation: registers a systemd realtime timer that fires with an OnCalendar policy.
+                If a timer had expired while a machine was off/asleep, it will fire upon resume.
+                See https://wiki.archlinux.org/title/systemd/Timers for details.
+              '';
+            };
+            onCalendar = mkOption {
+              type = types.str;
+              default = "weekly";
+              description = lib.mdDoc ''
+                Frequency of periodic updates.
+                See https://wiki.archlinux.org/title/systemd/Timers for details.
+              '';
+            };
+          };
+        });
+        default = { enable = false; };
+      };
+    };
+  };
+
 
 in
 {
@@ -76,16 +120,30 @@ in
       [{ name = "flathub"; location = "https://dl.flathub.org/repo/flathub.flatpakrepo"; }]
     '';
   };
+
   update = mkOption {
-    type = types.bool;
-    default = false;
+    type = with types; submodule updateOptions;
+    default = { onActivation = false; auto = { enable = false; onCalendar = "weekly"; }; };
     description = lib.mdDoc ''
       Whether to enable flatpak to upgrade applications during
       {command}`nixos` system activation. The default is `false`
       so that repeated invocations of {command}`nixos-rebuild switch` are idempotent.
 
-      implementation: appends --or-update to each flatpak install command.
+      Applications pinned to a specific commit hash will not be updated.
+
+      If {command}`auto.enable = true` a periodic update will be scheduled with (approximately)
+      weekly recurrence.
+
+      See https://wiki.archlinux.org/title/systemd/Timers for more information on systemd timers.
+    '';
+    example = literalExpression ''
+      # Update applications at system activation. Afterwards schedule (approximately) weekly updates.
+      update = {
+        auto = {
+            enable = true;
+            onCalendar = "weekly";
+        };
+      };
     '';
   };
-
 }

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -40,7 +40,7 @@ in
         export PATH=${lib.makeBinPath (with pkgs; [ systemd ])}:$PATH
 
         $DRY_RUN_CMD systemctl is-system-running -q && \
-          systemctl --user start flatpak-managed.service || true
+          systemctl --user start flatpak-managed-install.service || true
       '';
     };
 

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -8,7 +8,7 @@ in
   options.services.flatpak = import ./default.nix { inherit cfg lib pkgs; };
 
   config = lib.mkIf osConfig.services.flatpak.enable {
-    systemd.user.services."flatpak-managed" = {
+    systemd.user.services."flatpak-managed-install" = {
       Unit = {
         After = [
           "network.target"
@@ -23,6 +23,16 @@ in
         Type = "oneshot";
         ExecStart = "${import ./installer.nix {inherit cfg pkgs; installation = installation; }}";
       };
+    };
+
+    systemd.user.timers."flatpak-managed-install" = lib.mkIf config.services.flatpak.update.auto.enable {
+      Unit.Description = "flatpak update schedule";
+      Timer = {
+        Unit = "flatpak-managed-install";
+        OnCalendar = "${config.services.flatpak.update.auto.onCalendar}";
+        Persistent = "true";
+      };
+      Install.WantedBy = [ "timers.target" ];
     };
 
     home.activation = {

--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -1,13 +1,14 @@
 { cfg, pkgs, installation ? "system", ... }:
 
 let
+  updateApplications = cfg.update.onActivation || cfg.update.auto.enable;
   flatpakInstallCmd = installation: update: { appId, origin ? "flathub", commit ? null, ... }: ''
     ${pkgs.flatpak}/bin/flatpak --${installation} --noninteractive --no-auto-pin install \
-        ${if update then ''--or-update'' else ''''} ${origin} ${appId}
+        ${if update && commit == null then ''--or-update'' else ''''} ${origin} ${appId}
 
     ${if commit == null
         then '' ''
-        else ''${pkgs.flatpak}/bin/flatpak --${installation} unpdate --commit="${commit}" ${origin} ${appId}
+        else ''${pkgs.flatpak}/bin/flatpak --${installation} update --noninteractive  --commit="${commit}" ${appId}
     ''}
   '';
 
@@ -20,13 +21,13 @@ let
   mkFlatpakInstallCmd = installation: update: packages: builtins.foldl' (x: y: x + y) '''' (flatpakInstall installation update packages);
   mkFlatpakAddRemoteCmd = installation: remotes: builtins.foldl' (x: y: x + y) '''' (flatpakAddRemote installation remotes);
 in
-    pkgs.writeShellScript "flatpak-managed-install" ''
-        # This script is triggered at build time by a transient systemd unit.
-        set -eu
+pkgs.writeShellScript "flatpak-managed-install" ''
+  # This script is triggered at build time by a transient systemd unit.
+  set -eu
 
-        # Configure remotes
-        ${mkFlatpakAddRemoteCmd installation cfg.remotes}
+  # Configure remotes
+  ${mkFlatpakAddRemoteCmd installation cfg.remotes}
 
-        # Install packages
-        ${mkFlatpakInstallCmd installation cfg.update cfg.packages}
-      ''
+  # Install packages
+  ${mkFlatpakInstallCmd installation updateApplications cfg.packages}
+''

--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -1,39 +1,32 @@
 { cfg, pkgs, installation ? "system", ... }:
 
 let
-  flatpakInstallCmd = installation: { appId, origin ? "flathub", commit ? null, ... }: ''
-    ${pkgs.flatpak}/bin/flatpak --${installation} --noninteractive --no-auto-pin install ${origin} ${appId}
+  flatpakInstallCmd = installation: update: { appId, origin ? "flathub", commit ? null, ... }: ''
+    ${pkgs.flatpak}/bin/flatpak --${installation} --noninteractive --no-auto-pin install \
+        ${if update then ''--or-update'' else ''''} ${origin} ${appId}
+
     ${if commit == null
         then '' ''
         else ''${pkgs.flatpak}/bin/flatpak --${installation} unpdate --commit="${commit}" ${origin} ${appId}
-    ''}'';
+    ''}
+  '';
 
   flatpakAddRemoteCmd = installation: { name, location, args ? null, ... }: ''
     ${pkgs.flatpak}/bin/flatpak remote-add --${installation} --if-not-exists ${if args == null then "" else args} ${name} ${location}
   '';
   flatpakAddRemote = installation: remotes: map (flatpakAddRemoteCmd installation) remotes;
-  flatpakInstall = installation: packages: map (flatpakInstallCmd installation) packages;
+  flatpakInstall = installation: update: packages: map (flatpakInstallCmd installation update) packages;
 
-  mkFlatpakInstallCmd = installation: packages: builtins.foldl' (x: y: x + y) '''' (flatpakInstall installation packages);
+  mkFlatpakInstallCmd = installation: update: packages: builtins.foldl' (x: y: x + y) '''' (flatpakInstall installation update packages);
   mkFlatpakAddRemoteCmd = installation: remotes: builtins.foldl' (x: y: x + y) '''' (flatpakAddRemote installation remotes);
-  mkFlatpakInstallScript = installation: pkgs.writeShellScript "flatpak-managed-install" ''
-    # This script is triggered at build time by a transient systemd unit.
-    set -eu
-
-    # Configure remotes
-    ${mkFlatpakAddRemoteCmd installation cfg.remotes}
-
-    # Insall packages
-    ${mkFlatpakInstallCmd installation cfg.packages}
-  '';
 in
-pkgs.writeShellScript "flatpak-managed-install" ''
-  # This script is triggered at build time by a transient systemd unit.
-  set -eu
+    pkgs.writeShellScript "flatpak-managed-install" ''
+        # This script is triggered at build time by a transient systemd unit.
+        set -eu
 
-  # Configure remotes
-  ${mkFlatpakAddRemoteCmd installation cfg.remotes}
+        # Configure remotes
+        ${mkFlatpakAddRemoteCmd installation cfg.remotes}
 
-  # Insall packages
-  ${mkFlatpakInstallCmd installation cfg.packages}
-''
+        # Install packages
+        ${mkFlatpakInstallCmd installation cfg.update cfg.packages}
+      ''

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -7,7 +7,7 @@ in
   options.services.flatpak = import ./default.nix { inherit cfg lib pkgs; };
 
   config = lib.mkIf config.services.flatpak.enable {
-    systemd.services."flatpak-managed" = {
+    systemd.services."flatpak-managed-install" = {
       wants = [
         "network-online.target"
       ];
@@ -18,6 +18,14 @@ in
         Type = "oneshot";
         ExecStart = "${import ./installer.nix {inherit cfg pkgs; installation = installation; }}";
       };
+    };
+    systemd.timers."flatpak-managed-install" = lib.mkIf config.services.flatpak.update.auto.enable {
+      timerConfig = {
+        Unit = "flatpak-managed-install";
+        OnCalendar = "${config.services.flatpak.update.auto.onCalendar}";
+        Persistent = "true";
+      };
+      wantedBy = [ "timers.target" ];
     };
   };
 }


### PR DESCRIPTION
Closes #4.

Adds the capability to update installed applications at activation, and periodically.

Automated updates are not enable by default, so each system activation is idempotent.

# Api changes

Set
```nix
services.flatpak.update.onActivation = true;
```
to enable updates at system activation. The default is `false`
so that repeated invocations of `nixos-rebuild switch` are idempotent. Applications 
pinned to a specific commit hash will not be updated.

Periodic updates can be enabled  by setting:
```nix
services.flatpak.update = {
  auto = {
    enable = true;
    onCalendar = "weekly"; # Default value
  };
};
```
Auto updates trigger on system activation.

# Readiness
* [x] Tested on nixos
* [x] Tested on home-manager
* [x] Doc updated