### PR TITLE
Only uninstall packages managed by this module

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -43,7 +43,7 @@ in
     };
 
     home.activation = {
-      start-service = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      flatpak-managed-install = lib.hm.dag.entryAfter [ "reloadSystemd" ] ''
         export PATH=${lib.makeBinPath (with pkgs; [ systemd ])}:$PATH
 
         $DRY_RUN_CMD systemctl is-system-running -q && \

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -144,4 +144,14 @@ in
       };
     '';
   };
+
+  uninstallUnmanagedPackages = mkOption {
+    type = with types; bool;
+    default = false;
+    description = lib.mdDoc ''
+      If enabled, uninstall packages not managed by this module on activation.
+      I.e. if packages were installed via Flatpak directly instead of this module,
+      they would get uninstalled on the next activation
+    '';
+  };
 }


### PR DESCRIPTION
First of all thanks for creating this module! Convergent mode feels like the right the approach of combining Flatpak and NixOS to me, so I'm happy this exists.

Before this PR, there was an issue of packages being overridden on activation of the module, meaning if packages were installed outside of this module, they would get uninstalled on the next activation, and only the packages declared in this module would be left. This felt like a design flaw to me so I decided to fix it, I hope you agree and that this was not an intentional design choice.

This PR introduces a state file that keeps track of the module's modifications, so that they can be managed separately from imperatively introduced modifications. This is largely inspired by the way home manager handles [dconf settings](https://github.com/nix-community/home-manager/blob/master/modules/misc/dconf.nix). However, this module needs to work for both system and user installations, so it cannot rely on the home manager activation flow. To work around that, I put a symlink to the state file in the `gcroots` folder of the respective installation, which prevents it from being garbage collected. I couldn't find any conventions on how this should be handled, so it could probably be improved in the future. The only issue I can currently see with this approach is that the state file derivation would not be being garbage collected even if this module is removed. This would be easy to solve with home manager, but then it would need a separate implementation depending on the installation. Anyway, this shouldn't be too big of an issue, as it's just a text file that doesn't link to anything else that won't be garbage collected.

The state file is a JSON object so that more data can be added later. This is relevant as I would like to work on implementing overrides in this module in a similar fashion if this goes through. That way the state of the overrides could be stored in the same file.