### PR TITLE
Add overrides management

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -43,7 +43,7 @@ in
     };
 
     home.activation = {
-      start-service = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      flatpak-managed-install = lib.hm.dag.entryAfter [ "reloadSystemd" ] ''
         export PATH=${lib.makeBinPath (with pkgs; [ systemd ])}:$PATH
 
         $DRY_RUN_CMD systemctl is-system-running -q && \

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -119,6 +119,23 @@ in
     '';
   };
 
+  overrides = mkOption {
+    type = with types; attrsOf (attrsOf (attrsOf (either str (listOf str))));
+    default = {};
+    description = lib.mdDoc ''
+      Applies the provided attribute set into a Flatpak overrides file with the
+      same structure, keeping externally applied changes
+    '';
+    example = literalExpression ''
+      {
+        # Array entries will be merged with externally applied values
+        "com.visualstudio.code".Context.sockets = ["wayland" "!x11" "!fallback-x11"];
+        # String entries will override externally applied values
+        global.Environment.LC_ALL = "C.UTF-8";
+      };
+    '';
+  };
+
   update = mkOption {
     type = with types; submodule updateOptions;
     default = { onActivation = false; auto = { enable = false; onCalendar = "weekly"; }; };

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -144,4 +144,14 @@ in
       };
     '';
   };
+
+  uninstallUnmanagedPackages = mkOption {
+    type = with types; bool;
+    default = false;
+    description = lib.mdDoc ''
+      If enabled, uninstall packages not managed by this module on activation.
+      I.e. if packages were installed via Flatpak directly instead of this module,
+      they would get uninstalled on the next activation
+    '';
+  };
 }

--- a/modules/overrides.jq
+++ b/modules/overrides.jq
@@ -1,0 +1,42 @@
+# Convert entry value into array
+def values($value): if ($value | type) == "string" then [$value] else ($value // []) end;
+
+# State aliases
+  ($old_state.overrides[$app_id] // {}) as $old
+| ($new_state.overrides[$app_id] // {}) as $new
+
+# Map sections that exist in either active or new state (ignore old)
+| $active + $new | keys | map (
+  . as $section | {"section_key": $section, "section_value": (
+
+      # Map entries that exist in either active or new state (ignore old)
+      ($active[$section] // {}) + ($new[$section] // {}) | keys | map (
+        . as $entry | { "entry_key": $entry, "entry_value": (
+
+            # Entry value aliases
+              $active[$section][$entry] as $active_value
+            | $new[$section][$entry]    as $new_value
+            | $old[$section][$entry]    as $old_value
+
+            # Use new value if it is a string
+            | if ($new_value | type) == "string" then $new_value
+              else
+                # Otherwise remove old values from the active ones, and add the new ones
+                values($active_value) - values($old_value) + values($new_value)
+
+                # Remove empty arrays and duplicate values
+                | select(. != []) | unique
+                
+                # Convert array into Flatpak string array format
+                | join(";")
+              end
+          )}
+        )
+
+      # Remove empty arrays
+      | select(. != [])
+    )}
+  )[]
+
+# Generate the final overrides file
+| "[\(.section_key)]", (.section_value[] | "\(.entry_key)=\(.entry_value)"), ""


### PR DESCRIPTION
This PR builds on top of PR #23, as it relies on a similar strategy to separately manage the declarative and imperative states. If/when that PR is merged I'll rebase this PR to only include the relevant commit.

This wasn't a trivial task and was mainly accomplished using jq, the logic of which has been separated into the `
modules/overrides.jq` file. The installer simply provides the needed values to it by looping over previously and currently managed overrides, then reading their active (the actual Flatpak overrides files), old and new states (the files introduced in #23) from the respective files.

The actual logic to determine a value for an overrides entry is quite simple:
- If the new value is a string, simply override the active/old value
- If the value is an array, perform the following set arithmetic: `active - old + new`