### PR TITLE
installer: don't uninstall on empty OLD_STATE.

### DIFF
--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -30,13 +30,16 @@ let
 
   flatpakUninstallCmd = installation: {}: ''
     # Uninstall all packages that are present in the old state but not the new one
-    ${pkgs.jq}/bin/jq -r -n \
-      --argjson old "$OLD_STATE" \
-      --argjson new "$NEW_STATE" \
-      '($old.packages - $new.packages)[]' \
+    # $OLD_STATE and $NEW_STATE are globals, declared in the output of pkgs.writeShellScript.
+    if [ "$OLD_STATE" != "{}" ]; then
+      ${pkgs.jq}/bin/jq -r -n \
+        --argjson old "$OLD_STATE" \
+        --argjson new "$NEW_STATE" \
+        '($old.packages - $new.packages)[]' \
       | while read -r APP_ID; do
           ${pkgs.flatpak}/bin/flatpak uninstall --${installation} -y $APP_ID
-        done
+      done
+    fi
   '';
 
   flatpakInstallCmd = installation: update: { appId, origin ? "flathub", commit ? null, ... }: ''


### PR DESCRIPTION
Check that `OLD_STATE` has been populated before attempting to diff it with `NEW_STATE`,
when determining what packages to uninstall.

Fixes the following error:
```
jq: error (at <unknown>): null (null) and array (["im.riot.R...) cannot be subtracted
```

This is the case on newly provisioned instances, with no flatpaks previously installed (either managed by `nix-flatpak` or unmanaged).