### PR TITLE
Fixed Broken Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Using flake, installing `nix-flatpak` as a NixOs module would look something lik
 ```
 
 Depending on how config and inputs are derived `homeManagerModules` import can be flaky. Here's an example of how `homeManagerModules` is imported on my nixos systems config in [modules/home-manager/desktop/nixos/default.nix](https://github.com/gmodena/config/blob/5b3c1ce979881700f9f5ead88f2827f06143512f/modules/home-manager/desktop/nixos/default.nix#L17). `flake-inputs` is a special extra arg set in the repo `flake.nix`
-[mkNixosConfiguration]([https://github.com/gmodena/config/blob/main/flake.nix#L29](https://github.com/gmodena/config/blob/5b3c1ce979881700f9f5ead88f2827f06143512f/flake.nix#L29).
+[mkNixosConfiguration](https://github.com/gmodena/config/blob/5b3c1ce979881700f9f5ead88f2827f06143512f/flake.nix#L29).
  
 ### Remotes
 By default `nix-flatpak` will add the flathub remote. Remotes can be manually


### PR DESCRIPTION
# Description

There were two links where there should only be one. They both pointed to the same line in the same file. I chose the link that didn't point to the main branch because line numbers are likely to change on main.

# Note

I've added a suggestion in case the other link is preferred.