### PR TITLE
systemd: start unit after multi-user.target

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -18,17 +18,18 @@ in
     systemd.user.services."flatpak-managed-install" = {
       Unit = {
         After = [
-          "network.target"
+          "multi-user.target" # ensures that network & connectivity have been setup.
         ];
       };
       Install = {
         WantedBy = [
-          "default.target"
+          "default.target" # multi-user target with a GUI. For a desktop, this is typically going to be the graphical.target
         ];
       };
       Service = {
-        Type = "oneshot";
+        Type = "oneshot"; # TODO: should this be an async startup, to avoid blocking on network at boot ?
         ExecStart = import ./installer.nix { inherit cfg pkgs lib installation; };
+        RemainAfterExit = "yes";
       };
     };
 

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -29,7 +29,6 @@ in
       Service = {
         Type = "oneshot"; # TODO: should this be an async startup, to avoid blocking on network at boot ?
         ExecStart = import ./installer.nix { inherit cfg pkgs lib installation; };
-        RemainAfterExit = "yes";
       };
     };
 

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -8,14 +8,15 @@ in
 
   config = lib.mkIf config.services.flatpak.enable {
     systemd.services."flatpak-managed-install" = {
-      wants = [
-        "network-online.target"
-      ];
       wantedBy = [
-        "multi-user.target"
+        "default.target" # multi-user target with a GUI. For a desktop, this is typically going to be the graphical.target
+      ];
+      after = [
+        "multi-user.target" # ensures that network & connectivity have been setup.
       ];
       serviceConfig = {
-        Type = "oneshot";
+        Type = "oneshot"; # TODO: should this be an async startup, to avoid blocking on network at boot ?
+        RemainAfterExit = "yes";
         ExecStart = import ./installer.nix { inherit cfg pkgs lib installation; };
       };
     };

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -16,7 +16,6 @@ in
       ];
       serviceConfig = {
         Type = "oneshot"; # TODO: should this be an async startup, to avoid blocking on network at boot ?
-        RemainAfterExit = "yes";
         ExecStart = import ./installer.nix { inherit cfg pkgs lib installation; };
       };
     };


### PR DESCRIPTION
Start the `flatpak-managed-install` service after `multi-user.target`.
This should ensure that network interfaces are up, and connectivity has been established.

Fixes #30 