### PR TITLE
installer: add fallback values to uninstall jq command to avoid bugs

### DIFF
--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -32,15 +32,13 @@ let
   flatpakUninstallCmd = installation: {}: ''
     # Uninstall all packages that are present in the old state but not the new one
     # $OLD_STATE and $NEW_STATE are globals, declared in the output of pkgs.writeShellScript.
-    if [ "$OLD_STATE" != "{}" ]; then
-      ${pkgs.jq}/bin/jq -r -n \
-        --argjson old "$OLD_STATE" \
-        --argjson new "$NEW_STATE" \
-        '($old.packages - $new.packages)[]' \
-      | while read -r APP_ID; do
-          ${pkgs.flatpak}/bin/flatpak uninstall --${installation} -y $APP_ID
-      done
-    fi
+    ${pkgs.jq}/bin/jq -r -n \
+      --argjson old "$OLD_STATE" \
+      --argjson new "$NEW_STATE" \
+      '(($old.packages // []) - ($new.packages // []))[]' \
+    | while read -r APP_ID; do
+        ${pkgs.flatpak}/bin/flatpak uninstall --${installation} -y $APP_ID
+    done
   '';
 
   overridesDir =


### PR DESCRIPTION
This is a follow up on https://github.com/gmodena/nix-flatpak/pull/24#issuecomment-1917639479. I looked into it and turns out I actually already implemented it correctly for overrides, using fallback values in `jq` (i.e. `null // []` and `null // {}`), so that bug shouldn't occur there. But I think it's also worth implementing it that way for uninstalls, as it's a bit more resilient than comparing old state to an empty object. F.e. if the old state is not an empty object, but is missing the "packages" key for some reason, this would still work (as opposed to the current solution). It's not really necessary right now, but it might avoid bugs in the future.