### PR TITLE
Bug | Option Documents Break Nix Build

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,3 +6,8 @@ A list of folks that helped with this project.
   * Improve readme.
 * [tmarkov](https://github.com/tmarkov) 
   * Add compatibility with stand-alone home-manager.
+* [ReedClanton](https://github.com/ReedClanton)
+  * README.md:
+    * Fixed broken link and typo.
+  * Fixed Broken Build:
+    * Fixed build issue related to option descriptions.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ services.flatpak.update.auto = {
 Auto updates trigger on system activation.
 
 Under the hood, updates are scheduled by realtime systemd timers. `onCalendar` accepts systemd's
-`update.auto.OnCalendar` expressions. Timers are persisted across sleep / resume cycles.
+`update.auto.onCalendar` expressions. Timers are persisted across sleep / resume cycles.
 See https://wiki.archlinux.org/title/systemd/Timers for more information. 
 
 ### Storage

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -83,7 +83,9 @@ let
           };
         });
         default = { enable = false; };
-		description = lib.mdDoc "Test fix";
+        description = lib.mdDoc ''
+          Test fix
+        '';
       };
     };
   };

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -5,17 +5,17 @@ let
     options = {
       name = mkOption {
         type = types.str;
-        description = lib.mdDoc "The remote name";
+        description = lib.mdDoc "The remote name. This name is what will be used when installing flatpak(s) from this repo.";
         default = "flathub";
       };
       location = mkOption {
         type = types.str;
-        description = lib.mdDoc "The remote location";
+        description = lib.mdDoc "The remote location. Must be a valid URL of a flatpak repo.";
         default = "https://dl.flathub.org/repo/flathub.flatpakrepo";
       };
       args = mkOption {
         type = types.nullOr types.str;
-        description = "Extra arguments to pass to flatpak remote-add";
+        description = "Extra arguments to pass to flatpak remote-add.";
         example = [ "--verbose" ];
         default = null;
       };
@@ -31,14 +31,14 @@ let
 
       commit = mkOption {
         type = types.nullOr types.str;
-        description = lib.mdDoc "Hash id of the app commit to install";
+        description = lib.mdDoc "Hash id of the app commit to install.";
         default = null;
       };
 
       origin = mkOption {
         type = types.str;
         default = "flathub";
-        description = lib.mdDoc "App repository origin (default: flathub)";
+        description = lib.mdDoc "App repository origin (default: flathub).";
       };
     };
   };
@@ -52,7 +52,7 @@ let
           Whether to enable flatpak to upgrade applications during
           {command}`nixos` system activation. The default is `false`
           so that repeated invocations of {command}`nixos-rebuild switch` are idempotent.
-          
+
           implementation: appends --or-update to each flatpak install command.
         '';
       };
@@ -84,8 +84,7 @@ let
         });
         default = { enable = false; };
         description = lib.mdDoc ''
-          Test fix
-          test 2
+          Value(s) in this Nix set are used to configure the behavior of the auto updater.
         '';
       };
     };
@@ -128,7 +127,7 @@ in
     default = {};
     description = lib.mdDoc ''
       Applies the provided attribute set into a Flatpak overrides file with the
-      same structure, keeping externally applied changes
+      same structure, keeping externally applied changes.
     '';
     example = literalExpression ''
       {
@@ -172,7 +171,7 @@ in
     description = lib.mdDoc ''
       If enabled, uninstall packages not managed by this module on activation.
       I.e. if packages were installed via Flatpak directly instead of this module,
-      they would get uninstalled on the next activation
+      they would get uninstalled on the next activation.
     '';
   };
 }

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -83,6 +83,7 @@ let
           };
         });
         default = { enable = false; };
+		description = lib.mdDoc "Test fix";
       };
     };
   };

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -52,7 +52,7 @@ let
           Whether to enable flatpak to upgrade applications during
           {command}`nixos` system activation. The default is `false`
           so that repeated invocations of {command}`nixos-rebuild switch` are idempotent.
-
+          
           implementation: appends --or-update to each flatpak install command.
         '';
       };

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -93,7 +93,7 @@ in
   packages = mkOption {
     type = with types; listOf (coercedTo str (appId: { inherit appId; }) (submodule packageOptions));
     default = [ ];
-    description = mkDoc ''
+    description = lib.mdDoc ''
       Declares a list of applications to install.
     '';
     example = literalExpression ''
@@ -110,7 +110,7 @@ in
   remotes = mkOption {
     type = with types; listOf (coercedTo str (name: { inherit name location; }) (submodule remoteOptions));
     default = [{ name = "flathub"; location = "https://dl.flathub.org/repo/flathub.flatpakrepo"; }];
-    description = mkDoc ''
+    description = lib.mdDoc ''
       Declare a list of flatpak repositories.
     '';
     example = literalExpression ''

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -52,7 +52,7 @@ let
           Whether to enable flatpak to upgrade applications during
           {command}`nixos` system activation. The default is `false`
           so that repeated invocations of {command}`nixos-rebuild switch` are idempotent.
-
+          
           implementation: appends --or-update to each flatpak install command.
         '';
       };
@@ -66,7 +66,7 @@ let
                 Whether to enable flatpak to upgrade applications during
                 {command}`nixos` system activation, and scheudle periodic updates
                 afterwards.
-
+                
                 implementation: registers a systemd realtime timer that fires with an OnCalendar policy.
                 If a timer had expired while a machine was off/asleep, it will fire upon resume.
                 See https://wiki.archlinux.org/title/systemd/Timers for details.
@@ -85,6 +85,7 @@ let
         default = { enable = false; };
         description = lib.mdDoc ''
           Test fix
+          test 2
         '';
       };
     };
@@ -146,12 +147,12 @@ in
       Whether to enable flatpak to upgrade applications during
       {command}`nixos` system activation. The default is `false`
       so that repeated invocations of {command}`nixos-rebuild switch` are idempotent.
-
+      
       Applications pinned to a specific commit hash will not be updated.
-
+      
       If {command}`auto.enable = true` a periodic update will be scheduled with (approximately)
       weekly recurrence.
-
+      
       See https://wiki.archlinux.org/title/systemd/Timers for more information on systemd timers.
     '';
     example = literalExpression ''


### PR DESCRIPTION
# Description

Two issue existed with the options documentation that caused build failures when `documentation.nixos.enable` and `documentation.nixos.includeAllModules` are set to `true`.

The first issue was that `mkDoc` was used rather than `lib.mdDoc` in two locations. `mkDoc` isn't valid, so I replaced both instances of it with `lib.mdDoc`.

The second issue was that not all options of `nix-flatpak` had descriptions. This also causes a build failure.

In addition to fixing the two issues above that cause build failures, I also:

* Fixed a typo in `README.md`.
* Made minor additions and corrections to existing option docs.
* Added spaces so option docs would be rendered correctly:
    * The way multi-line string blocks work in Nix is that the indent is determined by the line that's indented the least.
    * Thus all lines should be indented the same, even blank lines.

# Why Wasn't it Noticed Sooner

By default `documentation.nixos.enable` is `true` and `documentation.nixos.includeAllModules` is `false`. The latter value used to default to `true`, but was changed due to build performance concerns for NixOps users. Having said that, there has been discussion of turning the default back to `true` for non NixOps users. If this is done, then everyone who uses this module will end up with broken system builds.

In short, I noticed first because I was the first person to use this module and set `documentation.nixos.includeAllModules` to `true`.