### PR TITLE
installer: manage remotes state.

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -5,7 +5,7 @@ let
 in
 {
 
-  options.services.flatpak = (import ./options.nix { inherit lib pkgs; })
+  options.services.flatpak = (import ./options.nix { inherit config lib pkgs; })
   // {
     enable = with lib; mkOption {
       type = types.bool;

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,18 +1,21 @@
 { config, lib, pkgs, ... }@args:
 let
-  cfg = config.services.flatpak;
+  cfg = lib.warnIf (! isNull config.services.flatpak.uninstallUnmanagedPackages)
+    "uninstallUnmanagedPackages is deprecated since nix-flatpak 0.4.0 and will be removed in 1.0.0. Use uninstallUnamanged instead."
+    config.services.flatpak;
   installation = "user";
 in
 {
 
   options.services.flatpak = (import ./options.nix { inherit config lib pkgs; })
-  // {
+    // {
     enable = with lib; mkOption {
       type = types.bool;
       default = args.osConfig.services.flatpak.enable or false;
       description = mkDoc "Whether to enable nix-flatpak declarative flatpak management in home-manager.";
     };
   };
+
 
   config = lib.mkIf config.services.flatpak.enable {
     systemd.user.services."flatpak-managed-install" = {
@@ -53,5 +56,4 @@ in
 
     xdg.enable = true;
   };
-
 }

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -4,7 +4,7 @@ let
   installation = "system";
 in
 {
-  options.services.flatpak = import ./options.nix { inherit lib pkgs; };
+  options.services.flatpak = import ./options.nix { inherit config lib pkgs; };
 
   config = lib.mkIf config.services.flatpak.enable {
     systemd.services."flatpak-managed-install" = {

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,6 +1,8 @@
 { config, lib, pkgs, ... }:
 let
-  cfg = config.services.flatpak;
+  cfg = lib.warnIf (! isNull config.services.flatpak.uninstallUnmanagedPackages)
+    "uninstallUnmanagedPackages is deprecated since nix-flatpak 0.4.0 and will be removed in 1.0.0. Use uninstallUnamanged instead."
+    config.services.flatpak;
   installation = "system";
 in
 {

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ config, lib, ... }:
 with lib;
 let
   remoteOptions = _: {
@@ -165,13 +165,22 @@ in
     '';
   };
 
+  # TODO: trigger a lib.warn if this option is set
   uninstallUnmanagedPackages = mkOption {
     type = with types; bool;
     default = false;
     description = lib.mdDoc ''
-      If enabled, uninstall packages not managed by this module on activation.
-      I.e. if packages were installed via Flatpak directly instead of this module,
-      they would get uninstalled on the next activation.
-    '';
+      uninstallUnmanagedPackages is deprecated since nix-flatpak 0.4.0 and will be
+  removed in 1.0.0. Use uninstallUnamanged instead.'';
+  };
+
+  uninstallUnmanaged = mkOption {
+    type = with types; bool;
+    default = config.services.flatpak.uninstallUnmanagedPackages || false;
+    description = lib.mdDoc ''
+        If enabled, uninstall packages and delete remotes not managed by this module on activation.
+        I.e. if packages were installed via Flatpak directly instead of this module,
+        they would get uninstalled on the next activation. The same applies to remotes manually setup via `flatpak remote-add`
+      '';
   };
 }

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -124,7 +124,7 @@ in
 
   overrides = mkOption {
     type = with types; attrsOf (attrsOf (attrsOf (either str (listOf str))));
-    default = {};
+    default = { };
     description = lib.mdDoc ''
       Applies the provided attribute set into a Flatpak overrides file with the
       same structure, keeping externally applied changes.
@@ -165,22 +165,20 @@ in
     '';
   };
 
-  # TODO: trigger a lib.warn if this option is set
   uninstallUnmanagedPackages = mkOption {
-    type = with types; bool;
-    default = false;
+    type = lib.types.nullOr (lib.types.bool);
+    default = null;
     description = lib.mdDoc ''
-      uninstallUnmanagedPackages is deprecated since nix-flatpak 0.4.0 and will be
-  removed in 1.0.0. Use uninstallUnamanged instead.'';
+      uninstallUnmanagedPackages is deprecated. Use uninstallUnamanged instead.'';
   };
 
   uninstallUnmanaged = mkOption {
     type = with types; bool;
     default = config.services.flatpak.uninstallUnmanagedPackages || false;
     description = lib.mdDoc ''
-        If enabled, uninstall packages and delete remotes not managed by this module on activation.
-        I.e. if packages were installed via Flatpak directly instead of this module,
-        they would get uninstalled on the next activation. The same applies to remotes manually setup via `flatpak remote-add`
-      '';
+      If enabled, uninstall packages and delete remotes not managed by this module on activation.
+      I.e. if packages were installed via Flatpak directly instead of this module,
+      they would get uninstalled on the next activation. The same applies to remotes manually setup via `flatpak remote-add`
+    '';
   };
 }

--- a/testing-base/flake.lock
+++ b/testing-base/flake.lock
@@ -3,12 +3,12 @@
     "flatpaks": {
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-lVdzO395c6c0K4mHaqw84iSAy4P2/H7QS38RsKs0rFY=",
-        "path": "/nix/store/8mgi1kq0wcb3s9nhwnnfdwjnhj1nj4q3-source",
+        "narHash": "sha256-nwNvEEHwmg1yIcsr4UMgUNhbDhACjisetLn2ln1lZkc=",
+        "path": "/nix/store/ax9fayy482xr69g8lpy5zpsb91nfzay4-source",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/8mgi1kq0wcb3s9nhwnnfdwjnhj1nj4q3-source",
+        "path": "/nix/store/ax9fayy482xr69g8lpy5zpsb91nfzay4-source",
         "type": "path"
       }
     },

--- a/testing-base/flatpak.nix
+++ b/testing-base/flatpak.nix
@@ -10,7 +10,7 @@
   }];
 
   services.flatpak.update.auto.enable = false;
-  services.flatpak.uninstallUnmanagedPackages = true;
+  services.flatpak.uninstallUnmanaged = false;
   services.flatpak.packages = [
     #{ appId = "com.brave.Browser"; origin = "flathub"; }
     #"com.obsproject.Studio"


### PR DESCRIPTION
Remotes removed from nix-flatpak config declaration will be uninstalled at system activation.

Add the capability to delete unmanged remotes at system activation.

Rename `uninstallUnmanagedPackages` to a more generic `uninstallUnmanaged`.
Trigger warning when deprecated options are set.

Initial work for  #32 