### PR TITLE
options: fix uninstallUnmanaged default value.

### DIFF
--- a/modules/options.nix
+++ b/modules/options.nix
@@ -174,7 +174,8 @@ in
 
   uninstallUnmanaged = mkOption {
     type = with types; bool;
-    default = config.services.flatpak.uninstallUnmanagedPackages || false;
+    default = (if isNull config.services.flatpak.uninstallUnmanagedPackages then false else
+    config.services.flatpak.uninstallUnmanagedPackages) || false;
     description = lib.mdDoc ''
       If enabled, uninstall packages and delete remotes not managed by this module on activation.
       I.e. if packages were installed via Flatpak directly instead of this module,


### PR DESCRIPTION
Coerce the `null` value to `false` when initializing the value of `uninstallUnmanaged` from the `uninstallUnmanagedPackages` option default value.

Fixes issue #61.