### PR TITLE
Add 5-second delay before attempting Flatpak updates

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -18,6 +18,7 @@ in
       ];
       serviceConfig = {
         Type = "oneshot"; # TODO: should this be an async startup, to avoid blocking on network at boot ?
+        ExecStartPre = "${pkgs.coreutils}/bin/sleep 5"; 
         ExecStart = import ./installer.nix { inherit cfg pkgs lib installation; };
       };
     };


### PR DESCRIPTION
Hello everyone,

I've submitted this pull request to resolve https://github.com/gmodena/nix-flatpak/issues/45, where `flatpak-managed-install.service` attempts Flatpak updates before NetworkManager can fully establish a network connection, leading to the service failing.

I've introduced a brief 5-second delay upon initial login after a reboot to address this. This minor adjustment ensures NetworkManager has adequate time to provide an IP address to our wireless network interface, preventing update failures due to premature connection attempts.

I welcome your insights and feedback on this approach to improve the reliability of the service update process.

If you have any questions, a troubleshooting discussion on the linked issue is available.

Thank!