### PR TITLE
modules: fix uninstallUnmanaged typo.

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }@args:
 let
   cfg = lib.warnIf (! isNull config.services.flatpak.uninstallUnmanagedPackages)
-    "uninstallUnmanagedPackages is deprecated since nix-flatpak 0.4.0 and will be removed in 1.0.0. Use uninstallUnamanged instead."
+    "uninstallUnmanagedPackages is deprecated since nix-flatpak 0.4.0 and will be removed in 1.0.0. Use uninstallUnmanaged instead."
     config.services.flatpak;
   installation = "user";
 in

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 let
   cfg = lib.warnIf (! isNull config.services.flatpak.uninstallUnmanagedPackages)
-    "uninstallUnmanagedPackages is deprecated since nix-flatpak 0.4.0 and will be removed in 1.0.0. Use uninstallUnamanged instead."
+    "uninstallUnmanagedPackages is deprecated since nix-flatpak 0.4.0 and will be removed in 1.0.0. Use uninstallUnmanaged instead."
     config.services.flatpak;
   installation = "system";
 in

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -169,7 +169,7 @@ in
     type = lib.types.nullOr (lib.types.bool);
     default = null;
     description = lib.mdDoc ''
-      uninstallUnmanagedPackages is deprecated. Use uninstallUnamanged instead.'';
+      uninstallUnmanagedPackages is deprecated. Use uninstallUnmanaged instead.'';
   };
 
   uninstallUnmanaged = mkOption {


### PR DESCRIPTION
Fix "uninstallUnamanged" typo to "uninstallUnmanaged" in doc and error strings.

Bug: #73 