### PR TITLE
installer: add support for flatpakref.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,12 @@ jobs:
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
     - run: nix flake check
+    - name: Run Nix tests
+      run: |
+        cd tests/
+        result=$(nix eval --impure --expr 'import ./ref-test.nix {}')
+        if [ "$result" != "[ ]" ]; then
+          echo "Test failed: Expected [], but got $result"
+          exit 1
+        fi
+      shell: bash

--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ Rebuild your system (or home-manager) for changes to take place.
 A `sha256` hash is required for  the flatpakref file. This can be generated with `nix-prefetch-url <uri>`.
 Omitting the `sha256` attribute will require an `impure` evaluation of the flake.
 
-When installing an application from a `flatpakref` it's remote will be added with the
-`SuggestRemoteName` attributed declared in the flatpakref file.
+When installing an application from a `flatpakref`, the application remote will be determined as follows:
+1. If the packageOptions contains an origin, use that as the label for the remote URL.
+2. If the package does not specify an origin, use the remote name suggested by the flatpakref (SuggestRemoteName).
+3. If neither the package sets an origin nor the flatpakref suggests a remote name, sanitize the application Name.
 
 ##### Unmanaged packages and remotes
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can pin a specific commit setting `commit=<hash>` attribute.
 Rebuild your system (or home-manager) for changes to take place.
 
 #### Flatpakref files
-[Flatpakref]() files can be installed by setting the `flatpakref` attribute to :
+[Flatpakref](https://docs.flatpak.org/en/latest/repositories.html#flatpakref-files) files can be installed by setting the `flatpakref` attribute to :
 ```nix
   services.flatpak.packages = [
     { flatpakref = "<uri>"; sha256="<hash>"; }

--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ You can pin a specific commit setting `commit=<hash>` attribute.
 
 Rebuild your system (or home-manager) for changes to take place.
 
+#### Flatpakref files
+[Flatpakref]() files can be installed by setting the `flatpakref` attribute to :
+```nix
+  services.flatpak.packages = [
+    { flatpakref = "<uri>"; sha256="<hash>"; }
+  ];
+```
+
+A `sha256` hash is required for  the flatpakref file. This can be generated with `nix-prefetch-url <uri>`.
+Omitting the `sha256` attribute will require an `impure` evaluation of the flake.
+
+When installing an application from a `flatpakref` it's remote will be added with the
+`SuggestRemoteName` attributed declared in the flatpakref file.
+
 ##### Unmanaged packages and remotes
 
 By default `nix-flatpak` will only manage (install/uninstall/update) packages declared in the

--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -72,11 +72,8 @@ let
     packages = (map
       (package:
         if utils.isFlatpakref package
-        then package // {
-          appId = flatpakrefCache.${(utils.sanitizeUrl package.flatpakref)}.Name;
-          origin = getRemoteNameFromFlatpakref null flatpakrefCache.${(utils.sanitizeUrl package.flatpakref)};
-        }
-        else package
+        then flatpakrefCache.${(utils.sanitizeUrl package.flatpakref)}.Name # application id from flatpakref
+        else package.appId
       )
       cfg.packages);
     overrides = cfg.overrides;

--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -62,13 +62,10 @@ let
       # Existing remotes (not from flatpakref)
       (map (builtins.getAttr "name") cfg.remotes) ++
       # Add remotes extracted from flatpakref URLs in packages
-      (builtins.filter (remote: remote != null) (map
+      map
         (package:
-          if utils.isFlatpakref package
-          then flatpakrefCache.${(utils.sanitizeUrl package.flatpakref)}.SuggestRemoteName
-          else null
-        )
-        cfg.packages));
+          flatpakrefCache.${(utils.sanitizeUrl package.flatpakref)}.SuggestRemoteName)
+        (builtins.filter (package: utils.isFlatpakref package) cfg.packages);
   });
 
   statePath = "${gcroots}/${stateFile.name}";

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -40,6 +40,17 @@ let
         default = "flathub";
         description = lib.mdDoc "App repository origin (default: flathub).";
       };
+
+      flatpakref = mkOption {
+        type = types.nullOr types.str;
+        description = lib.mdDoc "The flakeref URI of the app to install. ";
+        default = null;
+      };
+      sha256 = mkOption {
+        type = types.nullOr types.str;
+        description = lib.mdDoc "The sha256 hash of the URI to install. ";
+        default = null;
+      };
     };
   };
 

--- a/modules/ref.nix
+++ b/modules/ref.nix
@@ -1,0 +1,40 @@
+# utiliy function to manage flatpakref files
+{ pkgs, lib, ... }:
+let
+  # check if a value is a string
+  isString = value: builtins.typeOf value == "string";
+
+  # Check if a package declares a flatpakref
+  isFlatpakref = { flatpakref, ... }:
+    flatpakref != null && isString flatpakref;
+
+  # sanitize a URL to be used as a key in an attrset.
+  sanitizeUrl = url: builtins.replaceStrings [ "https://" "/" "." ":" ] [ "https_" "_" "_" "_" ] url;
+
+  # Fetch and convert an ini-like flatpakref file into an attrset, and cache it for future use
+  # within the same activation.
+  # We piggyback on builtins.fetchurl to fetch and cache flatpakref file. Pure nix evaluations
+  # requrie a sha256 hash to be provided.
+  # TODO: extract a generic ini-to-attrset function.
+  flatpakrefToAttrSet = {flatpakref, sha256, ...}: cache:
+    let updatedCache =
+     if builtins.hasAttr (sanitizeUrl flatpakref) cache then
+        cache
+     else
+        let
+            fetchurlArgs = if sha256 != null
+            then {url=flatpakref; sha256=sha256;}
+            else {url=flatpakref;};
+            iniContent = builtins.readFile ( builtins.fetchurl fetchurlArgs );
+            lines = builtins.split "\r?\n" iniContent;
+            parsed = builtins.filter (line: line != null) (map (line: builtins.match "(.*)=(.*)" (builtins.toString line) ) lines);
+
+            # Convert the list of key-value pairs into an attrset
+            attrSet = builtins.listToAttrs (map (pair: { name = builtins.elemAt pair 0; value = builtins.elemAt pair 1; }) parsed);
+        in
+          cache // { ${(sanitizeUrl flatpakref)} = attrSet; };
+     in updatedCache;
+ in
+ {
+    inherit isFlatpakref sanitizeUrl flatpakrefToAttrSet;
+ }

--- a/modules/ref.nix
+++ b/modules/ref.nix
@@ -1,15 +1,35 @@
 # utiliy function to manage flatpakref files
-{ pkgs, lib, ... }:
+{ lib, ... }:
 let
   # check if a value is a string
   isString = value: builtins.typeOf value == "string";
 
   # Check if a package declares a flatpakref
-  isFlatpakref = { flatpakref, ... }:
+  isFlatpakref = { flatpakref ? null, ... }:
     flatpakref != null && isString flatpakref;
 
   # sanitize a URL to be used as a key in an attrset.
   sanitizeUrl = url: builtins.replaceStrings [ "https://" "/" "." ":" ] [ "https_" "_" "_" "_" ] url;
+
+  # Extract the remote name from a package that declares a flatpakref:
+  # 1. if the package sets an origin, use that as label for the remote url.
+  # 2. if the package does not set an origin, use the remote name suggested by the flatpakref.
+  # 3. if the package does not set an origin and the flatpakref does not suggest a remote name, sanitize application Name.
+  getRemoteNameFromFlatpakref = origin: cache:
+    let
+      remoteName = origin;
+    in
+    if remoteName == null
+    then
+      let
+        flatpakrefdName =
+          if builtins.hasAttr "SuggestRemoteName" cache
+          then cache.SuggestRemoteName
+          else "${lib.toLower cache.Name}-origin";
+      in
+      flatpakrefdName
+    else
+      remoteName;
 
   # Fetch and convert an ini-like flatpakref file into an attrset, and cache it for future use
   # within the same activation.
@@ -39,5 +59,5 @@ let
     updatedCache;
 in
 {
-  inherit isFlatpakref sanitizeUrl flatpakrefToAttrSet;
+  inherit isFlatpakref sanitizeUrl flatpakrefToAttrSet getRemoteNameFromFlatpakref;
 }

--- a/tests/fixtures/package.flatpakref
+++ b/tests/fixtures/package.flatpakref
@@ -1,0 +1,8 @@
+[Flatpak Ref]
+Title=gedit
+Name=org.gnome.gedit
+Branch=stable
+Url=http://sdk.gnome.org/repo-apps/
+IsRuntime=false
+GPGKey=REDACTED
+DeployCollectionID=org.gnome.Apps

--- a/tests/ref-test.nix
+++ b/tests/ref-test.nix
@@ -8,6 +8,17 @@ let
   pwd = builtins.getEnv "PWD";
   fixturePath = "file://${pwd}/fixtures/package.flatpakref";
   fixtureHash = "040iig2yg2i28s5xc9cvp5syaaqq165idy3nhlpv8xn4f6zh4h1f";
+  expectedFixtureAttrSet = {
+    ${ref.sanitizeUrl fixturePath} = {
+      Title = "gedit";
+      Name = "org.gnome.gedit";
+      Branch = "stable";
+      Url = "http://sdk.gnome.org/repo-apps/";
+      IsRuntime = "false";
+      GPGKey = "REDACTED";
+      DeployCollectionID = "org.gnome.Apps";
+    };
+  };
 in
 runTests {
   testSanitizeUrl = {
@@ -47,31 +58,11 @@ runTests {
 
   testFlatpakrefToAttrSet = {
     expr = ref.flatpakrefToAttrSet { flatpakref = fixturePath; sha256 = null; } { };
-    expected = {
-      ${ref.sanitizeUrl fixturePath} = {
-        Title = "gedit";
-        Name = "org.gnome.gedit";
-        Branch = "stable";
-        Url = "http://sdk.gnome.org/repo-apps/";
-        IsRuntime = "false";
-        GPGKey = "REDACTED"; 
-        DeployCollectionID = "org.gnome.Apps";
-      };
-    };
+    expected = expectedFixtureAttrSet;
   };
 
   testFlatpakrefToAttrSetWithSha256 = {
     expr = ref.flatpakrefToAttrSet { flatpakref = fixturePath; sha256 = fixtureHash; } { };
-    expected = {
-      ${ref.sanitizeUrl fixturePath} = {
-        Title = "gedit";
-        Name = "org.gnome.gedit";
-        Branch = "stable";
-        Url = "http://sdk.gnome.org/repo-apps/";
-        IsRuntime = "false";
-        GPGKey = "REDACTED";
-        DeployCollectionID = "org.gnome.Apps";
-      };
-    };
+    expected = expectedFixtureAttrSet;
   };
 }

--- a/tests/ref-test.nix
+++ b/tests/ref-test.nix
@@ -1,0 +1,77 @@
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  inherit (pkgs) lib;
+  inherit (lib) runTests;
+  ref = import ../modules/ref.nix { inherit lib; };
+
+  pwd = builtins.getEnv "PWD";
+  fixturePath = "file://${pwd}/fixtures/package.flatpakref";
+  fixtureHash = "040iig2yg2i28s5xc9cvp5syaaqq165idy3nhlpv8xn4f6zh4h1f";
+in
+runTests {
+  testSanitizeUrl = {
+    expr = ref.sanitizeUrl "https://example.local";
+    expected = "https_example_local";
+  };
+
+  testIsFlatpakref = {
+    expr = ref.isFlatpakref { flatpakref = "https://example.local/package.flatpakref"; };
+    expected = true;
+  };
+
+  testIsFlatpakrefWithNull = {
+    expr = ref.isFlatpakref { flatpakref = null; };
+    expected = false;
+  };
+
+  testIsFlatpakrefWithMissing = {
+    expr = ref.isFlatpakref { appId = "local.example.Package"; };
+    expected = false;
+  };
+
+  testGetRemoteNameFromFlatpakrefWithOrigin = {
+    expr = ref.getRemoteNameFromFlatpakref "example" { SuggestRemoteName = "local"; };
+    expected = "example";
+  };
+
+  testGetRemoteNameWithSuggestedName = {
+    expr = ref.getRemoteNameFromFlatpakref null { SuggestRemoteName = "local"; };
+    expected = "local";
+  };
+
+  testGetRemoteNameWithPackageName = {
+    expr = ref.getRemoteNameFromFlatpakref null { Name = "Example"; };
+    expected = "example-origin";
+  };
+
+  testFlatpakrefToAttrSet = {
+    expr = ref.flatpakrefToAttrSet { flatpakref = fixturePath; sha256 = null; } { };
+    expected = {
+      ${ref.sanitizeUrl fixturePath} = {
+        Title = "gedit";
+        Name = "org.gnome.gedit";
+        Branch = "stable";
+        Url = "http://sdk.gnome.org/repo-apps/";
+        IsRuntime = "false";
+        GPGKey = "REDACTED"; 
+        DeployCollectionID = "org.gnome.Apps";
+      };
+    };
+  };
+
+  testFlatpakrefToAttrSetWithSha256 = {
+    expr = ref.flatpakrefToAttrSet { flatpakref = fixturePath; sha256 = fixtureHash; } { };
+    expected = {
+      ${ref.sanitizeUrl fixturePath} = {
+        Title = "gedit";
+        Name = "org.gnome.gedit";
+        Branch = "stable";
+        Url = "http://sdk.gnome.org/repo-apps/";
+        IsRuntime = "false";
+        GPGKey = "REDACTED";
+        DeployCollectionID = "org.gnome.Apps";
+      };
+    };
+  };
+}

--- a/tests/ref-test.nix
+++ b/tests/ref-test.nix
@@ -41,7 +41,7 @@ runTests {
     expected = false;
   };
 
-  testGetRemoteNameFromFlatpakrefWithOrigin = {
+  testGetRemoteNameWithOrigin = {
     expr = ref.getRemoteNameFromFlatpakref "example" { SuggestRemoteName = "local"; };
     expected = "example";
   };


### PR DESCRIPTION
**This is a WIP**.

Issue #78 

Adds support for installing application from a flatpakref uri.

## Changes

When installing from a flatpakref,  and packages will tracked in the gcroot state files:
1. a package will be stored, with `appId` and `origin` set to the flatpakref's `Name` and `SuggestRemoteName` respectively.
2. a remote with be stored labelled with  `SuggestRemoteName`. 

This should enable compatibility with state management APIs.

### Testing

Workflow: 
1. declare a flatpakref package.
2. on activation, the package and its remote are installed.
3. remove the flatpakref declaration.
4. on activation, the package and it's remote are removed.

- [x] Tested on a `testing-base` nixos VM , with nix-flatpak loaded as a home-manager module.
- [x] Tested on a `testing-base` nixos VM , with nix-flatpak loaded as a nixos module.

```
services.flatpak.remotes = lib.mkOptionDefault [{
   name = "flathub-beta";
   location = "https://flathub.org/beta-repo/flathub-beta.flatpakrepo";
};

services.flatpak.packages = [
    { 
      flatpakref="https://sober.vinegarhq.org/sober.flatpakref";
      sha256="1pj8y1xhiwgbnhrr3yr3ybpfis9slrl73i0b1lc9q89vhip6ym2l";
    }
  ];
```


#### Example state config.
 `cat /nix/var/nix/gcroots/flatpak-state.json`:
```
{
    "overrides": {},
    "packages": [
       "org.vinegarhq.Sober"
    ],
    "remotes": [
        "flathub",
        "flathub-beta",
        "sober"
    ]
}
```