### PR TITLE
testing-base: enable flatpak in vm base config.

### DIFF
--- a/testing-base/common.nix
+++ b/testing-base/common.nix
@@ -49,6 +49,8 @@
       #      xdg-desktop-portal-gtk
     ];
   };
-
+  
+  # install flatpak binary
+  services.flatpak.enable = true;
   system.stateVersion = "23.11";
 }

--- a/testing-base/flatpak.nix
+++ b/testing-base/flatpak.nix
@@ -1,9 +1,6 @@
 # home.nix
 { lib, ... }: {
 
-  # nix-flatpak setup
-  services.flatpak.enable = true;
-
   services.flatpak.remotes = lib.mkOptionDefault [{
     name = "flathub-beta";
     location = "https://flathub.org/beta-repo/flathub-beta.flatpakrepo";


### PR DESCRIPTION
Ensure that the flatpak binary will be available
also when building a VM variant that loads
nix-flatpak as an home-manager module.