### PR TITLE
ref: fix remote origin management

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,8 @@ A `sha256` hash is required for  the flatpakref file. This can be generated with
 Omitting the `sha256` attribute will require an `impure` evaluation of the flake.
 
 When installing an application from a `flatpakref`, the application remote will be determined as follows:
-1. If the packageOptions contains an origin, use that as the label for the remote URL.
-2. If the package does not specify an origin, use the remote name suggested by the flatpakref (SuggestRemoteName).
-3. If neither the package sets an origin nor the flatpakref suggests a remote name, sanitize the application Name.
+1. If the package does not specify an origin, use the remote name suggested by the flatpakref in `SuggestRemoteName`.
+2. If the flatpakref does not suggest a remote name, sanitize the flatpakref `Name` key with the same algo flatpak implements in [create_origin_remote_config()](https://github.com/flatpak/flatpak/blob/b730771bd793b34fb63fcbf292beed35476e5b92/common/flatpak-dir.c#L14423).
 
 ##### Unmanaged packages and remotes
 

--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -61,12 +61,15 @@ let
     # Iterate over remotes and handle remotes installed from flatpakref URLs
     remotes =
       # Existing remotes (not from flatpakref)
-      (map (builtins.getAttr "name") cfg.remotes) ++
-      # Add remotes extracted from flatpakref URLs in packages
-      map
-        (package:
-          utils.getRemoteNameFromFlatpakref package.origin flatpakrefCache.${(utils.sanitizeUrl package.flatpakref)})
-        (builtins.filter (package: utils.isFlatpakref package) cfg.packages);
+      (map (builtins.getAttr "name") cfg.remotes)
+      ++
+      # Add remotes extracted from flatpakref URLs in packages.
+      # flatpakref remote names will override any origin set in the package.
+      (builtins.filter (remote: !builtins.isNull remote)
+        (map
+          (package:
+            utils.getRemoteNameFromFlatpakref null flatpakrefCache.${(utils.sanitizeUrl package.flatpakref)})
+          (builtins.filter (package: utils.isFlatpakref package) cfg.packages)));
   });
 
   statePath = "${gcroots}/${stateFile.name}";

--- a/modules/remotes.nix
+++ b/modules/remotes.nix
@@ -16,13 +16,23 @@ let
     # Delete all remotes that are present in the old state but not the new one
     # $OLD_STATE and $NEW_STATE are globals, declared in the output of pkgs.writeShellScript.
     # If uninstallUnmanagedState is true, then the remotes will be deleted forcefully.
+    #
+    # Test if the remote exists before deleting it. This guards against two potential issues:
+    # 1. A Flatpakref might install non-enumerable remotes that are automatically deleted
+    #    when the application is uninstalled, so attempting to delete them without checking
+    #    could cause errors.
+    # 2. Users might manually delete apps/remotes, which could impact nix-flatpak state;
+    #    checking prevents errors if the remote has already been removed.
     ${pkgs.jq}/bin/jq -r -n \
       --argjson old "$OLD_STATE" \
       --argjson new "$NEW_STATE" \
        '(($old.remotes // []) - ($new.remotes // []))[]' \
       | while read -r REMOTE_NAME; do
-          ${pkgs.flatpak}/bin/flatpak remote-delete ${if uninstallUnmanaged then " --force " else " " } --${installation} $REMOTE_NAME
-
+          if ${pkgs.flatpak}/bin/flatpak --${installation} remotes --columns=name | grep -q "^$REMOTE_NAME$"; then
+            ${pkgs.flatpak}/bin/flatpak remote-delete ${if uninstallUnmanaged then " --force " else " " } --${installation} $REMOTE_NAME
+          else
+            echo "Remote '$REMOTE_NAME' not found in flatpak remotes"
+          fi
       done
   '';
 

--- a/tests/ref-test.nix
+++ b/tests/ref-test.nix
@@ -51,8 +51,18 @@ runTests {
     expected = "local";
   };
 
-  testGetRemoteNameWithPackageName = {
+  testGetRemoteNameWithNoSuggestedName = {
     expr = ref.getRemoteNameFromFlatpakref null { Name = "Example"; };
+    expected = "example-origin";
+  };
+
+  testGetRemoteNameWithNoSuggestedNameAndNameEndingWithDot = {
+    expr = ref.getRemoteNameFromFlatpakref null { Name = "Example."; };
+    expected = "example-origin";
+  };
+
+  testGetRemoteNameWithNoSuggestedNameAndNameStartingWithDot = {
+    expr = ref.getRemoteNameFromFlatpakref null { Name = ".Example"; };
     expected = "example-origin";
   };
 

--- a/tests/ref-test.nix
+++ b/tests/ref-test.nix
@@ -46,22 +46,22 @@ runTests {
     expected = "example";
   };
 
-  testGetRemoteNameWithSuggestedName = {
+  testGetRemoteNameWithSuggestRemoteName = {
     expr = ref.getRemoteNameFromFlatpakref null { SuggestRemoteName = "local"; };
     expected = "local";
   };
 
-  testGetRemoteNameWithNoSuggestedName = {
+  testGetRemoteNameWithoutSuggestRemoteName = {
     expr = ref.getRemoteNameFromFlatpakref null { Name = "Example"; };
     expected = "example-origin";
   };
 
-  testGetRemoteNameWithNoSuggestedNameAndNameEndingWithDot = {
+  testGetRemoteNameWithoutSuggestRemoteNameAndNameEndingWithDot = {
     expr = ref.getRemoteNameFromFlatpakref null { Name = "Example."; };
     expected = "example-origin";
   };
 
-  testGetRemoteNameWithNoSuggestedNameAndNameStartingWithDot = {
+  testGetRemoteNameWithoutSuggestRemoteNameAndNameStartingWithDot = {
     expr = ref.getRemoteNameFromFlatpakref null { Name = ".Example"; };
     expected = "example-origin";
   };


### PR DESCRIPTION
When a flatpakref file does not provide a SuggestRemoteName key, create an origin from the Name field.

This change implements the algorithm found in flatpak's create_origin_remote_config() function.

Remove the option of setting an origin label in packageOption. This option was poorly documented, and its default behavior ( labeling as "flathub" if no origin was set) would break system activation.

Fixes #90 