### PR TITLE
options: add uninstallUnused option

### DIFF
--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -112,6 +112,10 @@ let
     done
   '';
 
+  flatpakUninstallUnusedCmd = installation: ''
+    ${pkgs.flatpak}/bin/flatpak --${installation} uninstall --unused --noninteractive
+  '';
+
   overridesDir =
     if (installation == "system")
     then "/var/lib/flatpak/overrides"
@@ -204,13 +208,18 @@ pkgs.writeShellScript "flatpak-managed-install" ''
 
   # Uninstall remotes that have been removed from services.flatpak.packages
   # since the previous activation.
-  ${flatpakDeleteRemotesCmd installation cfg.uninstallUnmanaged {}}
+  ${flatpakDeleteRemotesCmd installation cfg.uninstallUnmanaged {}}  
 
   # Install packages
   ${mkFlatpakInstallCmd installation updateApplications cfg.packages}
 
   # Configure overrides
   ${flatpakOverridesCmd installation {}}
+
+  # Clean up installation
+  ${if cfg.uninstallUnused 
+    then flatpakUninstallUnusedCmd installation
+    else "# services.flatpak.uninstallUnused is not enabled "}  
 
   # Save state
   ${pkgs.coreutils}/bin/ln -sf ${stateFile} ${statePath}

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -198,4 +198,13 @@ in
       they would get uninstalled on the next activation. The same applies to remotes manually setup via `flatpak remote-add`
     '';
   };
+
+  uninstallUnused = mkOption {
+    type = with types; bool;
+    default = config.services.flatpak.uninstallUnmanaged || false;
+    description = ''
+      If enabled, uninstalls unused packages and runtimes.
+      Defaults to `config.services.flatpak.uninstallUnmanaged`, or `false`.
+    '';
+  };
 }


### PR DESCRIPTION
This PR introduces the capability to automatically uninstall unused packages by running `flatpak uninstall --unused` during activation or a scheduled update execution.

A new `services.flatpak.uninstallUnused` option is added, defaulting to `false`. This option is independent of `services.flatpak.uninstallUnmanaged`.

However, enabling `services.flatpak.uninstallUnmanaged` will automatically enable `services.flatpak.uninstallUnused`.

Closed #96 