### PR TITLE
Enable restart on failure and optionally exponential backoff

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -32,6 +32,10 @@ in
       Service = {
         Type = "oneshot"; # TODO: should this be an async startup, to avoid blocking on network at boot ?
         ExecStart = import ./installer.nix { inherit cfg pkgs lib installation; };
+        Restart = "on-failure";
+        RestartSec = config.services.flatpak.update.restartDelay;
+        RestartSteps = lib.mkIf config.services.flatpak.update.exponentialBackoff.enable config.services.flatpak.update.exponentialBackoff.steps;
+        RestartMaxDelaySec = lib.mkIf config.services.flatpak.update.exponentialBackoff.enable config.services.flatpak.update.exponentialBackoff.maxDelay;
       };
     };
 

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -18,7 +18,16 @@ in
 
 
   config = lib.mkIf config.services.flatpak.enable {
-    systemd.user.services."flatpak-managed-install" = {
+    systemd.user.services."flatpak-managed-install" = let
+      exponentialBackoff = if config.services.flatpak.restartOnFailure.exponentialBackoff.enable then {
+        RestartSteps = config.services.flatpak.restartOnFailure.exponentialBackoff.steps;
+        RestartMaxDelaySec = config.services.flatpak.restartOnFailure.exponentialBackoff.maxDelay;
+      } else {};
+      restartOptions = if config.services.flatpak.restartOnFailure.enable then {
+        Restart = "on-failure";
+        RestartSec = config.services.flatpak.restartOnFailure.restartDelay;
+      } // exponentialBackoff else {};
+    in {
       Unit = {
         After = [
           "multi-user.target" # ensures that network & connectivity have been setup.
@@ -32,11 +41,7 @@ in
       Service = {
         Type = "oneshot"; # TODO: should this be an async startup, to avoid blocking on network at boot ?
         ExecStart = import ./installer.nix { inherit cfg pkgs lib installation; };
-        Restart = "on-failure";
-        RestartSec = config.services.flatpak.update.restartDelay;
-        RestartSteps = lib.mkIf config.services.flatpak.update.exponentialBackoff.enable config.services.flatpak.update.exponentialBackoff.steps;
-        RestartMaxDelaySec = lib.mkIf config.services.flatpak.update.exponentialBackoff.enable config.services.flatpak.update.exponentialBackoff.maxDelay;
-      };
+      } // restartOptions;
     };
 
     systemd.user.timers."flatpak-managed-install" = lib.mkIf config.services.flatpak.update.auto.enable {

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -19,6 +19,10 @@ in
       serviceConfig = {
         Type = "oneshot"; # TODO: should this be an async startup, to avoid blocking on network at boot ?
         ExecStart = import ./installer.nix { inherit cfg pkgs lib installation; };
+        Restart = "on-failure";
+        RestartSec = config.services.flatpak.update.restartDelay;
+        RestartSteps = lib.mkIf config.services.flatpak.update.exponentialBackoff.enable config.services.flatpak.update.exponentialBackoff.steps;
+        RestartMaxDelaySec = lib.mkIf config.services.flatpak.update.exponentialBackoff.enable config.services.flatpak.update.exponentialBackoff.maxDelay;
       };
     };
     systemd.timers."flatpak-managed-install" = lib.mkIf config.services.flatpak.update.auto.enable {

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -4,6 +4,14 @@ let
     "uninstallUnmanagedPackages is deprecated since nix-flatpak 0.4.0 and will be removed in 1.0.0. Use uninstallUnmanaged instead."
     config.services.flatpak;
   installation = "system";
+  exponentialBackoff = if config.services.flatpak.restartOnFailure.exponentialBackoff.enable then {
+    RestartSteps = config.services.flatpak.restartOnFailure.exponentialBackoff.steps;
+    RestartMaxDelaySec = config.services.flatpak.restartOnFailure.exponentialBackoff.maxDelay;
+  } else {};
+  restartOptions = if config.services.flatpak.restartOnFailure.enable then {
+    Restart = "on-failure";
+    RestartSec = config.services.flatpak.restartOnFailure.restartDelay;
+    } // exponentialBackoff else {};
 in
 {
   options.services.flatpak = import ./options.nix { inherit config lib pkgs; };
@@ -19,11 +27,7 @@ in
       serviceConfig = {
         Type = "oneshot"; # TODO: should this be an async startup, to avoid blocking on network at boot ?
         ExecStart = import ./installer.nix { inherit cfg pkgs lib installation; };
-        Restart = "on-failure";
-        RestartSec = config.services.flatpak.update.restartDelay;
-        RestartSteps = lib.mkIf config.services.flatpak.update.exponentialBackoff.enable config.services.flatpak.update.exponentialBackoff.steps;
-        RestartMaxDelaySec = lib.mkIf config.services.flatpak.update.exponentialBackoff.enable config.services.flatpak.update.exponentialBackoff.maxDelay;
-      };
+      } // restartOptions;
     };
     systemd.timers."flatpak-managed-install" = lib.mkIf config.services.flatpak.update.auto.enable {
       timerConfig = {

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -61,6 +61,37 @@ let
 
   updateOptions = _: {
     options = {
+      restartDelay = mkOption {
+        type = types.str;
+        default = "60s";
+        description = ''
+            Delay (in as systemd timespan format) after which update or installation is going to be retried in case of failure.
+        '';
+      };
+      exponentialBackoff = {
+       enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+            Whether to enable exponential backoff in case of failure during installation or upgrade.
+        '';
+      };
+       steps = mkOption {
+        type = types.int;
+        default = 10;
+        description = ''
+            How many steps will be needed to reach the maximum restart delay.
+        '';
+      };
+
+      maxDelay = mkOption {
+        type = types.str;
+        default = "1h";
+        description = ''
+            Maximum delay (in as systemd timespan format) after which update or installation is going to be retried in case of failure.
+        '';
+      };
+      };
       onActivation = mkOption {
         type = types.bool;
         default = false;


### PR DESCRIPTION
I just implemented part of the changes we were discussing in #45.
I figured out that the stuff I was saying on the `WantedBy=` option does not make sense, since we need the service to start to have flatpaks installed and making the `Wantedby=` option empty prevents that, even on rebuilds. However, I only used the setup in testing-base/ to verify this.

I still wanted to have slightly better resilience to network failures, and the current solution goes hand in hand with the need of having the service started on each activation. 
My take on the problem makes the `flatpak-managed-install.service` automatically restart on failure with a customizable delay. The user has also the option to enable an exponential backoff strategy, with a customizable number of steps and maximum restart delay.

This has been implemented using the `systemd.service(5)` `Restart=`, `RestartSec=`, `RestartSteps=` and `RestartMaxDelaySec=` options.

So maybe this plus #110 could be a good solution for the issue mentioned in #45.

Let me know if you have any corrections or opinions, and thinks for considering my contribution!