### PR TITLE
restartOnFailure: fix option typo.

### DIFF
--- a/modules/options.nix
+++ b/modules/options.nix
@@ -252,11 +252,12 @@ in
   
   restartOnFailure = mkOption {
     type = with types; submodule restartOptions;
-    default = { enable = true; restartDelay = "60s"; exponentialBackoff = { enable = false; steps=10; maxDelat = "1h"; }; };
+    default = { enable = true; restartDelay = "60s"; exponentialBackoff = { enable = false; steps=10; maxDelay = "1h"; }; };
     description = ''
       If enabled, restart the flatpak-managed-install service in case of failure.
       It is possible to specify a restart delay and an exponential backoff strategy.
       '';
+  };
       
   uninstallUnused = mkOption {
     type = with types; bool;


### PR DESCRIPTION
Fixes a typo in options, and a missing semi-colon
after the block closing bracket.

Follow up to #127 for a small bug that was not caught in  code review and CI.

Tested locally in VM to confirm that the feature now works as expected.

cc @Nick1296 