### PR TITLE
installer: warning for manual app removal edge case

### DIFF
--- a/modules/installer.nix
+++ b/modules/installer.nix
@@ -108,7 +108,11 @@ let
       --argjson new "$NEW_STATE" \
       '(($old.packages // []) - ($new.packages // []))[]' \
     | while read -r APP_ID; do
-        ${pkgs.flatpak}/bin/flatpak uninstall --${installation} -y $APP_ID
+        if ${pkgs.flatpak}/bin/flatpak --${installation} list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q "^${appId}$"; then
+          ${pkgs.flatpak}/bin/flatpak uninstall --${installation} -y $APP_ID
+        else
+          echo "WARN: Application '${APP_ID}' was found in the state file, but not in '${installation}' installation"
+        fi
     done
   '';
 


### PR DESCRIPTION
Guard against cases where a user removes an application both manually and through
configuration between activations. This code path triggers when `uninstallUnmanaged=false`,
and nix-flatpak fails to clean up inconsistencies before reaching the uninstall phase.

Don't hard fail on uninstall of packages already manually removed by the user; 
display a warning message instead.

Successful activation should then reconcile old/new state and flatpak installation.

Fixes #126 
