### PR TITLE
flatpak: remove network side effects on activation

### DIFF
--- a/modules/flatpak/remotes.nix
+++ b/modules/flatpak/remotes.nix
@@ -7,7 +7,9 @@ let
       args-flag = ''${if args == null then "" else args}'';
     in
     ''
-      ${pkgs.flatpak}/bin/flatpak remote-add --${installation} --if-not-exists ${args-flag} ${gpg-import-flag} ${name} ${location}
+      if ! ${pkgs.flatpak}/bin/flatpak remotes --${installation} --columns=name | ${pkgs.gnugrep}/bin/grep -q '^${name}$'; then
+        ${pkgs.flatpak}/bin/flatpak remote-add --${installation} --if-not-exists ${args-flag} ${gpg-import-flag} ${name} ${location}
+      fi
     '';
 
   flatpakAddRemote = installation: remotes: map (flatpakAddRemotesCmd installation) remotes;

--- a/tests/idempotent-install-test.nix
+++ b/tests/idempotent-install-test.nix
@@ -1,0 +1,36 @@
+# Updates should be performed during activation when the installer is
+# executed at service start. They should not be performed when
+# the installer is executed by a timer.
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  inherit (pkgs) lib;
+  inherit (lib) runTests;
+  installation = "user";
+
+  pwd = builtins.getEnv "PWD";
+  flatpakrefUrl = "file://${pwd}/fixtures/package.flatpakref";
+  flatpakrefSha251 = "040iig2yg2i28s5xc9cvp5syaaqq165idy3nhlpv8xn4f6zh4h1f";
+
+  flatpakConfig = import ./config.nix;
+  cfg = flatpakConfig // {
+    packages = [
+      {
+        appId = "noop"; # appId is required here because we are injecting from the test suite without resolving options.nix defaults. 
+        flatpakref = flatpakrefUrl;
+        sha256 = flatpakrefSha251;
+        commit = "abc123";
+      }
+      { appId = "SomeAppId"; origin = "some-remote"; }
+
+    ];
+  };
+
+  install = import ../modules/flatpak/install.nix { inherit cfg pkgs lib installation; executionContext = "service-start"; };
+in
+runTests {
+  testInstall = {
+    expr = install.mkInstallCmd;
+    expected = "if ${pkgs.jq}/bin/jq -r -n --argjson old \"$OLD_STATE\" --arg appId \"org.gnome.gedit\" '$old.packages | index($appId) != null' | ${pkgs.gnugrep}/bin/grep -q true; then\n  if [[ -n \"abc123\" ]] && [[ \"$( ${pkgs.flatpak}/bin/flatpak --user info \"org.gnome.gedit\" --show-commit 2>/dev/null )\" != \"abc123\" ]]; then\n    ${pkgs.flatpak}/bin/flatpak --user --noninteractive update --commit=\"abc123\" org.gnome.gedit\n    : # No operation if no update command needs to run.\n  fi\nelse\n  ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  $(if ${pkgs.flatpak}/bin/flatpak --user list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q org.gnome.gedit; then\n    echo \"gedit-origin org.gnome.gedit\"\nelse\n    echo \"--from ${flatpakrefUrl}\"\nfi)\n\n${pkgs.flatpak}/bin/flatpak --user --noninteractive update --commit=\"abc123\" org.gnome.gedit\n\n  : # No operation if no install command needs to run.\nfi\nif ${pkgs.jq}/bin/jq -r -n --argjson old \"$OLD_STATE\" --arg appId \"SomeAppId\" '$old.packages | index($appId) != null' | ${pkgs.gnugrep}/bin/grep -q true; then\n  if [[ -n \"\" ]] && [[ \"$( ${pkgs.flatpak}/bin/flatpak --user info \"SomeAppId\" --show-commit 2>/dev/null )\" != \"\" ]]; then\n    \n    : # No operation if no update command needs to run.\n  fi\nelse\n  ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  some-remote SomeAppId\n\n\n  : # No operation if no install command needs to run.\nfi\n";
+  };
+}

--- a/tests/remotes-test.nix
+++ b/tests/remotes-test.nix
@@ -9,11 +9,11 @@ in
 runTests {
   testMkFlatpakAddRemotesCmd = {
     expr = installer.mkFlatpakAddRemotesCmd installation [{ name = "flathub"; location = "http://flathub"; }];
-    expected = "${pkgs.flatpak}/bin/flatpak remote-add --system --if-not-exists   flathub http://flathub\n";
+    expected = "if ! ${pkgs.flatpak}/bin/flatpak remotes --system --columns=name | ${pkgs.gnugrep}/bin/grep -q '^flathub$'; then\n  ${pkgs.flatpak}/bin/flatpak remote-add --system --if-not-exists   flathub http://flathub\nfi\n";
   };
 
   testMkFlatpakAddRemotesCmdCmdWithTrustedKeys = {
     expr = installer.mkFlatpakAddRemotesCmd installation [{ name = "flathub"; location = "http://flathub"; gpg-import = "trustedkeys.gpg"; }];
-    expected = "${pkgs.flatpak}/bin/flatpak remote-add --system --if-not-exists  --gpg-import=trustedkeys.gpg flathub http://flathub\n";
+    expected = "if ! ${pkgs.flatpak}/bin/flatpak remotes --system --columns=name | ${pkgs.gnugrep}/bin/grep -q '^flathub$'; then\n  ${pkgs.flatpak}/bin/flatpak remote-add --system --if-not-exists  --gpg-import=trustedkeys.gpg flathub http://flathub\nfi\n";
   };
 }

--- a/tests/update-on-activation-test.nix
+++ b/tests/update-on-activation-test.nix
@@ -23,13 +23,13 @@ runTests {
     # invoke the installer from a timer, when update.auto is disabled but update.onActivation is enabled.
     # Packages won't be updated.
     expr = timerExecutionContext.mkInstallCmd;
-    expected = "${pkgs.flatpak}/bin/flatpak --system --noninteractive    install   some-remote SomeAppId \n";
+    expected = "if ${pkgs.jq}/bin/jq -r -n --argjson old \"$OLD_STATE\" --arg appId \"SomeAppId\" '$old.packages | index($appId) != null' | ${pkgs.gnugrep}/bin/grep -q true; then\n  if [[ -n \"\" ]] && [[ \"$( ${pkgs.flatpak}/bin/flatpak --system info \"SomeAppId\" --show-commit 2>/dev/null )\" != \"\" ]]; then\n    \n    : # No operation if no update command needs to run.\n  fi\nelse\n  ${pkgs.flatpak}/bin/flatpak --system --noninteractive install  some-remote SomeAppId\n\n\n  : # No operation if no install command needs to run.\nfi\n";
   };
 
   testUpdate = {
     # invoke the installer at service start, when update.auto is disabled but update.onActivation is enabled.
     # Packages will be updated.
     expr = serviceStartExecutionContext.mkInstallCmd;
-    expected = "${pkgs.flatpak}/bin/flatpak --system --noninteractive  --or-update   install   some-remote SomeAppId \n";
+    expected = "${pkgs.flatpak}/bin/flatpak --system --noninteractive install --or-update some-remote SomeAppId\n\n";
   };
 }

--- a/tests/update-on-timer-test.nix
+++ b/tests/update-on-timer-test.nix
@@ -22,13 +22,13 @@ runTests {
     # invoke the installer on activation, when update.auto is enabled but update.onActivation is disabled.
     # Packages won't be updated.
     expr = serviceStartExecutionContext.mkInstallCmd;
-    expected = "${pkgs.flatpak}/bin/flatpak --system --noninteractive    install   some-remote SomeAppId \n";
+    expected = "if ${pkgs.jq}/bin/jq -r -n --argjson old \"$OLD_STATE\" --arg appId \"SomeAppId\" '$old.packages | index($appId) != null' | ${pkgs.gnugrep}/bin/grep -q true; then\n  if [[ -n \"\" ]] && [[ \"$( ${pkgs.flatpak}/bin/flatpak --system info \"SomeAppId\" --show-commit 2>/dev/null )\" != \"\" ]]; then\n    \n    : # No operation if no update command needs to run.\n  fi\nelse\n  ${pkgs.flatpak}/bin/flatpak --system --noninteractive install  some-remote SomeAppId\n\n\n  : # No operation if no install command needs to run.\nfi\n";
   };
 
   testUpdate = {
     # invoke the installer from a timer, when update.auto is enabled but update.onActivation is disabled.
     # Packages will be updated.
     expr = timerExecutionContext.mkInstallCmd;
-    expected = "${pkgs.flatpak}/bin/flatpak --system --noninteractive  --or-update   install   some-remote SomeAppId \n";
+    expected = "${pkgs.flatpak}/bin/flatpak --system --noninteractive install --or-update some-remote SomeAppId\n\n";
   };
 }


### PR DESCRIPTION
Checks whether packages and remotes need to be installed before executing flatpak commands.

Doing so avoid un-necessary network lookups and removes side effects from the installation process.

## Implementation

`nix-flatpak` tracks its state (installed packages, remotes and overrides) in a file within the nix store. This file is symlinked from a known location outside the store for easy access (e.g `$HOME/.local/state/home-manager/gcroots/flatpak-state.json `). However, this design creates a limitation: during build time, pure nix evaluation cannot access this state information because nix prohibits dereferencing symlinks outside the store.

With his PR the `nix-flatpak` state is evaluated at runtime (e.g., when executed via onActivation) by the installation script to check the following conditions for each remote and application:
 * The remote is already present in the system. No Flatpak commands will be executed.
 * `update.onActivation` and/or `update.auto` are enabled. Existing Flatpak applications will be updated.
 * The application is not present in the current state and should be installed.
 * The application is present in the current state but is now explicitly pinned to a different hash than the currently installed one. It will then be updated.

## Testing

Snapshot tests have been added under `tests/`. Integration tests have been run on a VM. Disabling networking allowed to simulate "offline" nixos activations.

Resolves #110 
Informs issues #45 #125