### PR TITLE
[PoC] install: handle local files.

### DIFF
--- a/modules/options.nix
+++ b/modules/options.nix
@@ -46,6 +46,12 @@ let
         description = "App repository origin (default: flathub).";
       };
 
+      path = mkOption {
+        type = types.nullOr types.str;
+        description = "Path to a local .flatpak file.";
+        default = null;
+      };
+
       flatpakref = mkOption {
         type = types.nullOr types.str;
         description = "The flakeref URI of the app to install. ";

--- a/tests/install-from-file-test.nix
+++ b/tests/install-from-file-test.nix
@@ -1,0 +1,29 @@
+# Updates should be performed during activation when the installer is
+# executed at service start. They should not be performed when
+# the installer is executed by a timer.
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+  inherit (pkgs) lib;
+  inherit (lib) runTests;
+  installation = "user";
+
+  flatpakConfig = import ./config.nix;
+  flatpakFilePath = "/path/to/some/app.flatpak";
+  cfg = flatpakConfig // {
+    packages = [
+      {
+        appId = "noop"; # appId is required here because we are injecting from the test suite without resolving options.nix defaults.
+        path = flatpakFilePath;
+      }
+    ];
+  };
+
+  install = import ../modules/flatpak/install.nix { inherit cfg pkgs lib installation; executionContext = "service-start"; };
+in
+runTests {
+  testInstall = {
+    expr = install.mkInstallCmd;
+    expected = "${pkgs.flatpak}/bin/flatpak --${installation} install --noninteractive ${flatpakFilePath}";
+  };
+}


### PR DESCRIPTION
This is a PoC to better understand requirements for #135.

It's very limited, and does not implement state management. Removing a declaration from `packages` won't uninstall the application on activation. 

Adds a `path` option to `packageOptions`
to support installation from local files.

Modify installer to generate a code path
for local installation.

Installing from local file won't create
a new remote, so no changes are required
to remote management.