### PR TITLE
systemd: fix incorrect unit name for timer

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -18,7 +18,7 @@ rec {
   };
 
   mkCommonTimerConfig = cfg: {
-    Unit = "flatpak-managed-install";
+    Unit = "flatpak-managed-install-timer";
     OnCalendar = cfg.update.auto.onCalendar;
     Persistent = "true";
   };


### PR DESCRIPTION
The timer used for managing automated updates was using the right service name, but pointing to the wrong unit.