### PR TITLE
Add Nick1296 to the contributors' credits.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,3 +16,5 @@ A list of folks that helped with this project.
   * Add override management.
 * [Lillecarl](https://github.com/Lillecarl)
   * Bugfix: missing path to coreutils commands.
+* [Nick1296](https://github.com/Nick1296)
+  * Enhanced the installer's reliability and added retry-on-error logic to the systemd unit.


### PR DESCRIPTION
Adds credits for retry-on-error logic
on systemd unit restarts introduced in PR #127.

cc / @Nick1296 