### PR TITLE
Fix location metadata

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   outputs = _:
     {
-      nixosModules = { nix-flatpak = import ./modules/nixos.nix; };
-      homeManagerModules = { nix-flatpak = import ./modules/home-manager.nix; };
+      nixosModules = { nix-flatpak = ./modules/nixos.nix; };
+      homeManagerModules = { nix-flatpak = ./modules/home-manager.nix; };
     };
 }


### PR DESCRIPTION
This way we solve 2 problems:

1. Warnings and errors will be attributed to the correct file
2. importing it multiple times will not cause redefinition errors