### PR TITLE
flatpak: install from bundle fil files.

### DIFF
--- a/modules/flatpak/state/compare_sha.jq
+++ b/modules/flatpak/state/compare_sha.jq
@@ -1,0 +1,38 @@
+# compare_sha.jq - Flatpak bundle nix store SHA256 change
+#
+# PURPOSE:
+#   Compares nis store SHA256 values for a specific Flatpak bundle between two state snapshots.
+#   Returns the application ID if SHA256 has changed, empty output if unchanged.
+#
+# USAGE:
+#   jq -n --argjson oldState '<JSON>' --argjson newState '<JSON>' --arg appId '<APP_ID>' -f compare_sha.jq
+#
+# PARAMETERS:
+#   $oldState  - Previous state JSON with packages array
+#   $newState  - Current state JSON with packages array  
+#   $appId     - Application ID to compare (e.g., "io.github.softfever.OrcaSlicer")
+#
+# INPUT FORMAT:
+#   {"packages":[{"appId":"com.example.App","sha256":"hash_value"},...]}
+#
+# OUTPUT:
+#   "app.id.string" - When SHA256 changed (including null transitions)
+#   (empty)         - When SHA256 unchanged
+#
+# EXAMPLES:
+#   Change detected:     "abc123" → "def456" or "abc123" → null
+#   No change:          "abc123" → "abc123" or null → null
+
+# Find package by appId and extract sha256
+
+def find_package_sha(state; appId):
+  if state.packages then
+    (state.packages | map(select(.appId == appId)) | .[0].sha256 // null)
+  else
+    null
+  end;
+
+# Main comparison logic - returns appId if changed, empty if not
+(find_package_sha($oldState; $appId)) as $old_sha |
+(find_package_sha($newState; $appId)) as $new_sha |
+if ($old_sha != $new_sha) then $appId else empty end

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -56,6 +56,15 @@ let
         description = "The sha256 hash of the URI to install. ";
         default = null;
       };
+
+      bundle = mkOption {
+        type = types.nullOr types.str;
+        description = ''
+            Path to a local Flatpak bundle to install. The file name should follow Flatpak's conventions:
+            https://docs.flatpak.org/en/latest/conventions.html
+          '';
+        default = null;
+      };
     };
   };
 

--- a/tests/idempotent-install-test.nix
+++ b/tests/idempotent-install-test.nix
@@ -2,35 +2,97 @@
 # executed at service start. They should not be performed when
 # the installer is executed by a timer.
 { pkgs ? import <nixpkgs> { } }:
-
 let
   inherit (pkgs) lib;
   inherit (lib) runTests;
   installation = "user";
-
   pwd = builtins.getEnv "PWD";
   flatpakrefUrl = "file://${pwd}/fixtures/package.flatpakref";
-  flatpakrefSha251 = "040iig2yg2i28s5xc9cvp5syaaqq165idy3nhlpv8xn4f6zh4h1f";
-
+  flatpakrefSha256 = "040iig2yg2i28s5xc9cvp5syaaqq165idy3nhlpv8xn4f6zh4h1f";
   flatpakConfig = import ./config.nix;
   cfg = flatpakConfig // {
     packages = [
       {
-        appId = "noop"; # appId is required here because we are injecting from the test suite without resolving options.nix defaults. 
+        appId = "org.gnome.gedit"; # Fixed: should match the expected appId
         flatpakref = flatpakrefUrl;
-        sha256 = flatpakrefSha251;
+        sha256 = flatpakrefSha256; # Fixed: corrected variable name
         commit = "abc123";
       }
       { appId = "SomeAppId"; origin = "some-remote"; }
-
     ];
   };
-
   install = import ../modules/flatpak/install.nix { inherit cfg pkgs lib installation; executionContext = "service-start"; };
 in
 runTests {
   testInstall = {
     expr = install.mkInstallCmd;
-    expected = "# Check if app exists in old state, handling both formats\nif $( ${pkgs.jq}/bin/jq -r -n --argjson old \"$OLD_STATE\" --arg appId \"org.gnome.gedit\" --from-file ${../modules/flatpak/state/app_exists.jq} | ${pkgs.gnugrep}/bin/grep -q true ); then\n  # App exists in old state, check if commit changed\n  if [[ -n \"abc123\" ]] && [[ \"$( ${pkgs.flatpak}/bin/flatpak --user info \"org.gnome.gedit\" --show-commit 2>/dev/null )\" != \"abc123\" ]]; then\n    ${pkgs.flatpak}/bin/flatpak --user --noninteractive update --commit=\"abc123\" org.gnome.gedit\n    : # No operation if no install command needs to run.\n  fi\nelse\n  ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  $(if ${pkgs.flatpak}/bin/flatpak --user list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q org.gnome.gedit; then\n    echo \"gedit-origin org.gnome.gedit\"\nelse\n    echo \"--from ${flatpakrefUrl}\"\nfi)\n\n${pkgs.flatpak}/bin/flatpak --user --noninteractive update --commit=\"abc123\" org.gnome.gedit\n\n  : # No operation if no install command needs to run.\nfi\n# Check if app exists in old state, handling both formats\nif $( ${pkgs.jq}/bin/jq -r -n --argjson old \"$OLD_STATE\" --arg appId \"SomeAppId\" --from-file ${../modules/flatpak/state/app_exists.jq} | ${pkgs.gnugrep}/bin/grep -q true ); then\n  # App exists in old state, check if commit changed\n  if [[ -n \"\" ]] && [[ \"$( ${pkgs.flatpak}/bin/flatpak --user info \"SomeAppId\" --show-commit 2>/dev/null )\" != \"\" ]]; then\n    \n    : # No operation if no install command needs to run.\n  fi\nelse\n  ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  some-remote SomeAppId\n\n\n  : # No operation if no install command needs to run.\nfi\n";
+    expected = ''if false; then
+    # Check if sha256 changed between OLD_STATE and NEW_STATE
+    changedSha256="$(${pkgs.jq}/bin/jq -ns \
+      --argjson oldState "$OLD_STATE" \
+      --argjson newState "$NEW_STATE" \
+      --arg appId "org.gnome.gedit" \
+      -f ${../modules/flatpak/state/compare_sha.jq})"
+
+    if [[ -n "$changedSha256" ]]; then
+      if ${pkgs.flatpak}/bin/flatpak --user info "org.gnome.gedit" &>/dev/null; then
+        ${pkgs.flatpak}/bin/flatpak --user uninstall -y "org.gnome.gedit"
+        : # No operation if no install command needs to run.
+      fi
+      
+      : # No operation if no install command needs to run.
+    fi
+else
+  # Check if app exists in old state, handling both formats
+  if $( ${pkgs.jq}/bin/jq -r -n --argjson old "$OLD_STATE" --arg appId "org.gnome.gedit" --from-file ${../modules/flatpak/state/app_exists.jq} | ${pkgs.gnugrep}/bin/grep -q true ); then
+    # App exists in old state, check if commit changed
+    if [[ -n "abc123" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --user info "org.gnome.gedit" --show-commit 2>/dev/null )" != "abc123" ]]; then
+      ${pkgs.flatpak}/bin/flatpak --user --noninteractive update --commit="abc123" org.gnome.gedit
+      : # No operation if no install command needs to run.
+    fi
+  else
+    ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  $(if ${pkgs.flatpak}/bin/flatpak --user list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q org.gnome.gedit; then
+    echo "gedit-origin org.gnome.gedit"
+else
+    echo "--from ${flatpakrefUrl}"
+fi)
+
+${pkgs.flatpak}/bin/flatpak --user --noninteractive update --commit="abc123" org.gnome.gedit
+
+    : # No operation if no install command needs to run.
+  fi
+fi
+if false; then
+    # Check if sha256 changed between OLD_STATE and NEW_STATE
+    changedSha256="$(${pkgs.jq}/bin/jq -ns \
+      --argjson oldState "$OLD_STATE" \
+      --argjson newState "$NEW_STATE" \
+      --arg appId "SomeAppId" \
+      -f ${../modules/flatpak/state/compare_sha.jq})"
+
+    if [[ -n "$changedSha256" ]]; then
+      if ${pkgs.flatpak}/bin/flatpak --user info "SomeAppId" &>/dev/null; then
+        ${pkgs.flatpak}/bin/flatpak --user uninstall -y "SomeAppId"
+        : # No operation if no install command needs to run.
+      fi
+      
+      : # No operation if no install command needs to run.
+    fi
+else
+  # Check if app exists in old state, handling both formats
+  if $( ${pkgs.jq}/bin/jq -r -n --argjson old "$OLD_STATE" --arg appId "SomeAppId" --from-file ${../modules/flatpak/state/app_exists.jq} | ${pkgs.gnugrep}/bin/grep -q true ); then
+    # App exists in old state, check if commit changed
+    if [[ -n "" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --user info "SomeAppId" --show-commit 2>/dev/null )" != "" ]]; then
+      
+      : # No operation if no install command needs to run.
+    fi
+  else
+    ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  some-remote SomeAppId
+
+
+    : # No operation if no install command needs to run.
+  fi
+fi
+'';
   };
 }

--- a/tests/install-from-file-test.nix
+++ b/tests/install-from-file-test.nix
@@ -1,0 +1,57 @@
+# Updates should be performed during activation when the installer is
+# executed at service start. They should not be performed when
+# the installer is executed by a timer.
+{ pkgs ? import <nixpkgs> { } }:
+let
+  inherit (pkgs) lib;
+  inherit (lib) runTests;
+  installation = "user";
+  flatpakConfig = import ./config.nix;
+  flatpakBundle = "app-bundle.flatpak";
+  cfg = flatpakConfig // {
+    packages = [
+      {
+        appId = "noop"; # appId is required here because we are injecting from the test suite without resolving options.nix defaults.
+        bundle = flatpakBundle;
+      }
+    ];
+  };
+  install = import ../modules/flatpak/install.nix { inherit cfg pkgs lib installation; executionContext = "service-start"; };
+in
+runTests {
+  testInstall = {
+    expr = install.mkInstallCmd;
+    expected = ''if true; then
+    # Check if sha256 changed between OLD_STATE and NEW_STATE
+    changedSha256="$(${pkgs.jq}/bin/jq -ns \
+      --argjson oldState "$OLD_STATE" \
+      --argjson newState "$NEW_STATE" \
+      --arg appId "noop" \
+      -f ${../modules/flatpak/state/compare_sha.jq})"
+
+    if [[ -n "$changedSha256" ]]; then
+      if ${pkgs.flatpak}/bin/flatpak --user info "noop" &>/dev/null; then
+        ${pkgs.flatpak}/bin/flatpak --user uninstall -y "noop"
+        : # No operation if no install command needs to run.
+      fi
+      ${pkgs.flatpak}/bin/flatpak --user --noninteractive install --bundle app-bundle.flatpak
+      : # No operation if no install command needs to run.
+    fi
+else
+  # Check if app exists in old state, handling both formats
+  if $( ${pkgs.jq}/bin/jq -r -n --argjson old "$OLD_STATE" --arg appId "noop" --from-file ${../modules/flatpak/state/app_exists.jq} | ${pkgs.gnugrep}/bin/grep -q true ); then
+    # App exists in old state, check if commit changed
+    if [[ -n "" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --user info "noop" --show-commit 2>/dev/null )" != "" ]]; then
+      
+      : # No operation if no install command needs to run.
+    fi
+  else
+    
+
+
+    : # No operation if no install command needs to run.
+  fi
+fi
+'';
+  };
+}

--- a/tests/state/compare_sha-test.nix
+++ b/tests/state/compare_sha-test.nix
@@ -1,0 +1,264 @@
+{ pkgs ? import <nixpkgs> { } }:
+let
+  inherit (pkgs) lib;
+  inherit (lib) runTests;
+  
+  jqScriptPath = ../../modules/flatpak/state/compare_sha.jq;
+  
+  runJqScript = { oldState, newState, appId }:
+    let
+      oldFile = pkgs.writeTextFile {
+        name = "old-state.json";
+        text = oldState;
+      };
+      newFile = pkgs.writeTextFile {
+        name = "new-state.json";
+        text = newState;
+      };
+      rawOutput = builtins.readFile (pkgs.runCommand "jq-result" {
+        buildInputs = [ pkgs.jq ];
+      } ''
+        ${pkgs.jq}/bin/jq -r -n \
+          --argjson oldState "$(cat ${oldFile})" \
+          --argjson newState "$(cat ${newFile})" \
+          --arg appId "${appId}" \
+          --from-file ${jqScriptPath} > $out
+      '');
+      # Handle the case where jq outputs nothing (empty)
+      output = if builtins.stringLength (lib.removeSuffix "\n" rawOutput) == 0
+        then null
+        else lib.removeSuffix "\n" rawOutput;
+    in
+      output;
+
+in runTests {
+  # Test: No change when SHA256 values are identical
+  testNoChange = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+          { appId = "com.other.app"; sha256 = "other_hash"; }
+        ];
+      };
+      newState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+          { appId = "com.other.app"; sha256 = "different_hash"; }
+        ];
+      };
+      appId = "com.some.app";
+    };
+    expected = null;  # empty output
+  };
+
+  # Test: Change detected when SHA256 values differ
+  testShaChanged = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+        ];
+      };
+      newState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "def456abc123"; }
+        ];
+      };
+      appId = "com.some.app";
+    };
+    expected = "com.some.app";
+  };
+
+  # Test: Change detected when SHA256 goes from value to null
+  testShaToNull = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+        ];
+      };
+      newState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; }  # no sha256 field
+        ];
+      };
+      appId = "com.some.app";
+    };
+    expected = "com.some.app";
+  };
+
+  # Test: Change detected when SHA256 goes from null to value
+  testNullToSha = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; }  # no sha256 field
+        ];
+      };
+      newState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+        ];
+      };
+      appId = "com.some.app";
+    };
+    expected = "com.some.app";
+  };
+
+  # Test: No change when both SHA256 values are null
+  testBothNull = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; }  # no sha256 field
+        ];
+      };
+      newState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; }  # no sha256 field
+        ];
+      };
+      appId = "com.some.app";
+    };
+    expected = null;  # empty output
+  };
+
+  # Test: App not found in old state
+  testAppNotInOldState = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [
+          { appId = "com.other.app"; sha256 = "other_hash"; }
+        ];
+      };
+      newState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+        ];
+      };
+      appId = "com.some.app";
+    };
+    expected = "com.some.app";
+  };
+
+  # Test: App not found in new state
+  testAppNotInNewState = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+        ];
+      };
+      newState = builtins.toJSON {
+        packages = [
+          { appId = "com.other.app"; sha256 = "other_hash"; }
+        ];
+      };
+      appId = "com.some.app";
+    };
+    expected = "com.some.app";
+  };
+
+  # Test: App not found in either state
+  testAppNotFound = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [
+          { appId = "com.other.app"; sha256 = "other_hash"; }
+        ];
+      };
+      newState = builtins.toJSON {
+        packages = [
+          { appId = "com.another.app"; sha256 = "another_hash"; }
+        ];
+      };
+      appId = "com.some.app";
+    };
+    expected = null;  # both null, so no change
+  };
+
+  # Test: Empty packages array in old state
+  testEmptyOldPackages = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [];
+      };
+      newState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+        ];
+      };
+      appId = "com.some.app";
+    };
+    expected = "com.some.app";
+  };
+
+  # Test: Empty packages array in new state
+  testEmptyNewPackages = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+        ];
+      };
+      newState = builtins.toJSON {
+        packages = [];
+      };
+      appId = "com.some.app";
+    };
+    expected = "com.some.app";
+  };
+
+  # Test: Missing packages field in old state
+  testMissingOldPackages = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        remotes = [];
+      };
+      newState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+        ];
+      };
+      appId = "com.some.app";
+    };
+    expected = "com.some.app";
+  };
+
+  # Test: Missing packages field in new state
+  testMissingNewPackages = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+        ];
+      };
+      newState = builtins.toJSON {
+        remotes = [];
+      };
+      appId = "com.some.app";
+    };
+    expected = "com.some.app";
+  };
+
+  # Test: Different app ID to ensure script is filtering correctly
+  testDifferentAppId = {
+    expr = runJqScript {
+      oldState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+          { appId = "com.example.app"; sha256 = "old_hash"; }
+        ];
+      };
+      newState = builtins.toJSON {
+        packages = [
+          { appId = "com.some.app"; sha256 = "abc123def456"; }
+          { appId = "com.example.app"; sha256 = "new_hash"; }
+        ];
+      };
+      appId = "com.example.app";
+    };
+    expected = "com.example.app";
+  };
+}

--- a/tests/update-on-activation-test.nix
+++ b/tests/update-on-activation-test.nix
@@ -1,35 +1,65 @@
-# Updates should be performed during activation when the installer is
-# executed at service start. They should not be performed when
-# the installer is executed by a timer.
 { pkgs ? import <nixpkgs> { } }:
-
 let
   inherit (pkgs) lib;
   inherit (lib) runTests;
   installation = "system";
-
   flatpakConfig = import ./config.nix;
   cfg = flatpakConfig // {
     update = flatpakConfig.update // {
-      onActivation = true;
+      auto = {
+        enable = true;
+      };
     };
+    # Add the missing packages configuration
+    packages = [
+      { appId = "SomeAppId"; origin = "some-remote"; }
+    ];
   };
-
-  serviceStartExecutionContext = import ../modules/flatpak/install.nix { inherit cfg pkgs lib installation; executionContext = "service-start"; };
   timerExecutionContext = import ../modules/flatpak/install.nix { inherit cfg pkgs lib installation; executionContext = "timer"; };
+  serviceStartExecutionContext = import ../modules/flatpak/install.nix { inherit cfg pkgs lib installation; executionContext = "service-start"; };
 in
 runTests {
   testDoNotUpdate = {
-    # invoke the installer from a timer, when update.auto is disabled but update.onActivation is enabled.
+    # invoke the installer on activation, when update.auto is enabled but update.onActivation is disabled.
     # Packages won't be updated.
-    expr = timerExecutionContext.mkInstallCmd;
-    expected =  "# Check if app exists in old state, handling both formats\nif $( ${pkgs.jq}/bin/jq -r -n --argjson old \"$OLD_STATE\" --arg appId \"SomeAppId\" --from-file ${../modules/flatpak/state/app_exists.jq} | ${pkgs.gnugrep}/bin/grep -q true ); then\n  # App exists in old state, check if commit changed\n  if [[ -n \"\" ]] && [[ \"$( ${pkgs.flatpak}/bin/flatpak --system info \"SomeAppId\" --show-commit 2>/dev/null )\" != \"\" ]]; then\n    \n    : # No operation if no install command needs to run.\n  fi\nelse\n  ${pkgs.flatpak}/bin/flatpak --system --noninteractive install  some-remote SomeAppId\n\n\n  : # No operation if no install command needs to run.\nfi\n";
-  };
-
-  testUpdate = {
-    # invoke the installer at service start, when update.auto is disabled but update.onActivation is enabled.
-    # Packages will be updated.
     expr = serviceStartExecutionContext.mkInstallCmd;
+    expected = ''if false; then
+    # Check if sha256 changed between OLD_STATE and NEW_STATE
+    changedSha256="$(${pkgs.jq}/bin/jq -ns \
+      --argjson oldState "$OLD_STATE" \
+      --argjson newState "$NEW_STATE" \
+      --arg appId "SomeAppId" \
+      -f ${../modules/flatpak/state/compare_sha.jq})"
+
+    if [[ -n "$changedSha256" ]]; then
+      if ${pkgs.flatpak}/bin/flatpak --system info "SomeAppId" &>/dev/null; then
+        ${pkgs.flatpak}/bin/flatpak --system uninstall -y "SomeAppId"
+        : # No operation if no install command needs to run.
+      fi
+      
+      : # No operation if no install command needs to run.
+    fi
+else
+  # Check if app exists in old state, handling both formats
+  if $( ${pkgs.jq}/bin/jq -r -n --argjson old "$OLD_STATE" --arg appId "SomeAppId" --from-file ${../modules/flatpak/state/app_exists.jq} | ${pkgs.gnugrep}/bin/grep -q true ); then
+    # App exists in old state, check if commit changed
+    if [[ -n "" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --system info "SomeAppId" --show-commit 2>/dev/null )" != "" ]]; then
+      
+      : # No operation if no install command needs to run.
+    fi
+  else
+    ${pkgs.flatpak}/bin/flatpak --system --noninteractive install  some-remote SomeAppId
+
+
+    : # No operation if no install command needs to run.
+  fi
+fi
+'';
+  };
+  testUpdate = {
+    # invoke the installer from a timer, when update.auto is enabled but update.onActivation is disabled.
+    # Packages will be updated.
+    expr = timerExecutionContext.mkInstallCmd;
     expected = "${pkgs.flatpak}/bin/flatpak --system --noninteractive install --or-update some-remote SomeAppId\n\n";
   };
 }


### PR DESCRIPTION
Adds a new `bundle` option to install application
from bundle files.

Local files will require a `sha256`, as generated by `nix-prefetch-url <uri>`.
Omitting the `sha256` attribute will require
an `impure` evaluation of the flake.

## Example

The bundle we want installed is located at:
```
/home/gmodena/config/bundles/io.github.softfever.OrcaSlicer.flatpak
```
The bundle must be renamed to a valid application id format (required by `flatpak`). 

For a pure evaluation of the flake, we need to provide the SHA-256 hash of the nix-store path of the file.
This can be obtained with:
```
$ nix-prefetch-url file:///home/gmodena/config/bundles/io.github.softfever.OrcaSlicer.flatpak
path is '/nix/store/6811vgfbzlbi9m3gdidg8jfs0gfbq8g2-io.github.softfever.OrcaSlicer.flatpak'
1p5wx6v3y6yyl43aqfh7dak9pln6461civv2z4p02srcvd6j63l0
```

To install with `nix-flpatpak`, use the new `bundle` option in the `packages` attrset:
```
services.flatpak.packages = [
    {
      bundle="file:///home/gmodena/config/bundles/io.github.softfever.OrcaSlicer.flatpak";
      appId="io.github.softfever.OrcaSlicer";
      sha256="1p5wx6v3y6yyl43aqfh7dak9pln6461civv2z4p02srcvd6j63l0";
   }
];
```
`appId`  **must** match the actual app id of the installed flaptak. E.g. what would be reported by `flattpak list` under **Application ID**.

Activate to install. E.g.:
```
$ sudo nixos-rebuild switch --flake '.#'
```
Note: if `sha256` was omitted, the activation must be impure:
```
$ sudo nixos-rebuild switch --flake '.#' --impure
```

To update the bundle, simply replace the file and update the sha256. If the sha256 is not changed between activations (e.g. `null` -> `null`), `nix-flatpak` won't attempt to update it.



Issue: #135