### PR TITLE
overrides: read base config from files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ might be a better fit.
 
 Flatpak overrides allow you to modify application permissions and environment variables. `nix-flatpak` provides two ways to manage overrides: inline `settings` and external `files`.
 
+**WARNING**: using these settings will overwrite system/user flatpak override files and could cause data loss. Backup
+your files before enabling `.settings` and/or `.files`.
+
 #### Settings (inline configuration)
 
 Use `services.flatpak.overrides.settings` to declare overrides directly in your nix configuration:
@@ -319,7 +322,7 @@ Use `services.flatpak.overrides.settings` to declare overrides directly in your 
 }
 ```
 
-**Backwards compatibility:** The legacy format `services.flatpak.overrides = { "app.id" = {...}; }` (without the `.settings` wrapper) is still supported.
+**Backwards compatibility:** The legacy  (`nix-flatpak` <= 0.7) format `services.flatpak.overrides = { "app.id" = {...}; }` (without the `.settings` wrapper) is still supported.
 
 #### Files (external override files)
 

--- a/README.md
+++ b/README.md
@@ -2,43 +2,57 @@
 
 # nix-flatpak
 
-Declarative flatpak manager for NixOS inspired by [declarative-flatpak](https://github.com/in-a-dil-emma/declarative-flatpak) and nix-darwin's [homebrew](https://github.com/LnL7/nix-darwin/blob/master/modules/homebrew.nix) module.
-NixOs and home-manager modules are provided for system wide or user flatpaks installation.
+Declarative flatpak manager for NixOS inspired by
+[declarative-flatpak](https://github.com/in-a-dil-emma/declarative-flatpak) and
+nix-darwin's
+[homebrew](https://github.com/LnL7/nix-darwin/blob/master/modules/homebrew.nix)
+module. NixOs and home-manager modules are provided for system wide or user
+flatpaks installation.
 
 ## Versioning
 
 We use Git tags and branches to manage versions:
 
 - **`0.7.0`** → Current stable release.
-- **`latest`** → Always points to the most recent stable version (`0.7.0` as of now).
+- **`latest`** → Always points to the most recent stable version (`0.7.0` as of
+  now).
 - **`main`** → Unstable, development branch.
 
-
-This project is released as a [flake](https://nixos.wiki/wiki/Flakes), and is published
-on [flakehub](https://flakehub.com/flake/gmodena/nix-flatpak) and [flakestry](https://flakestry.dev/flake/github/gmodena/nix-flatpak/0.7.0).
-
+This project is released as a [flake](https://nixos.wiki/wiki/Flakes), and is
+published on [flakehub](https://flakehub.com/flake/gmodena/nix-flatpak) and
+[flakestry](https://flakestry.dev/flake/github/gmodena/nix-flatpak/0.7.0).
 
 ## Background
 
-This project was inspired by  Martin Wimpress' [Blending NixOS with Flathub for friends and family](https://talks.nixcon.org/nixcon-2023/talk/MNUFFP/)
+This project was inspired by Martin Wimpress'
+[Blending NixOS with Flathub for friends and family](https://talks.nixcon.org/nixcon-2023/talk/MNUFFP/)
 talk at NixCon 2023.
 
+For implementation details and info about how this project came to be, see my
+[Flatpaks The Nix Way](https://talks.nixcon.org/nixcon-2025/talk/XJ9JLH/) talk
+at NixCon 2025.
+[slides](https://nowave.it/docs/nixcon25-flatpaks_the_nix_way.pdf).
 
-For implementation details and info about how this project came to be, see my [Flatpaks The Nix Way](https://talks.nixcon.org/nixcon-2025/talk/XJ9JLH/) talk at NixCon 2025. [slides](https://nowave.it/docs/nixcon25-flatpaks_the_nix_way.pdf).
+`nix-flatpak` follows a
+[convergent mode](https://flyingcircus.io/blog/thoughts-on-systems-management-methods/)
+approach to package management (described in
+[this thread](https://discourse.nixos.org/t/feature-discussion-declarative-flatpak-configuration/26767/2)):
+the target system state description is not exhaustive, and there's room for
+divergence across builds and rollbacks. For a number of desktop applications I
+want to be able to track the latest version, or allow them to auto update. For
+such applications, a convergent approach is a reasonable tradeoff wrt system
+reproducibility. YMMV.
 
-`nix-flatpak` follows a [convergent mode](https://flyingcircus.io/blog/thoughts-on-systems-management-methods/) approach to package management (described in [this thread](https://discourse.nixos.org/t/feature-discussion-declarative-flatpak-configuration/26767/2)):
-the target system state description is not exhaustive, and there's room for divergence across builds
-and rollbacks.
-For a number of desktop applications I want to be able to track the latest version, or allow them to auto update.
-For such applications, a convergent approach is a reasonable tradeoff wrt system reproducibility. YMMV.
-
-Flatpak applications are installed by systemd oneshot service triggered at system activation. Depending on
-the number of applications to install, this could increase activation time significantly. 
+Flatpak applications are installed by systemd oneshot service triggered at
+system activation. Depending on the number of applications to install, this
+could increase activation time significantly.
 
 ### installation
 
-Releases are tagged with [semantic versioning](https://semver.org/). Versions below `1.0.0` are considered early, development, releases.
-Users can track a version by passing its release tag as `ref`
+Releases are tagged with [semantic versioning](https://semver.org/). Versions
+below `1.0.0` are considered early, development, releases. Users can track a
+version by passing its release tag as `ref`
+
 ```nix
 ...
 nix-flatpak.url = "github:gmodena/nix-flatpak/?ref=v0.7.0";
@@ -46,6 +60,7 @@ nix-flatpak.url = "github:gmodena/nix-flatpak/?ref=v0.7.0";
 ```
 
 The `latest` tag will always point to the most recent release.
+
 ```nix
 ...
 nix-flatpak.url = "github:gmodena/nix-flatpak/?ref=latest";
@@ -53,6 +68,7 @@ nix-flatpak.url = "github:gmodena/nix-flatpak/?ref=latest";
 ```
 
 The `main` branch is considered unstable, and _might_ break installs.
+
 ```nix
 ...
 nix-flatpak.url = "github:gmodena/nix-flatpak/";
@@ -64,7 +80,11 @@ nix-flatpak.url = "github:gmodena/nix-flatpak/";
 Flakes are the recommended and officially supported installation method, but
 under the hood `nix-flatpak` is just a Nix module.
 
-`nix-flatpak` is not available in channels and needs to be manually downloaded and imported. Nixpkgs users can use the [fetchFromGithub](https://ryantm.github.io/nixpkgs/builders/fetchers/#fetchfromgithub) fetcher:
+`nix-flatpak` is not available in channels and needs to be manually downloaded
+and imported. Nixpkgs users can use the
+[fetchFromGithub](https://ryantm.github.io/nixpkgs/builders/fetchers/#fetchfromgithub)
+fetcher:
+
 ```
 pkgs.fetchFromGitHub {
     owner = "gmodena";
@@ -73,12 +93,15 @@ pkgs.fetchFromGitHub {
     hash = "sha256-7ZCulYUD9RmJIDULTRkGLSW1faMpDlPKcbWJLYHoXcs=";
   };
 ```
+
 The package `hash` can be generated with:
+
 ```bash
 nix-prefetch-github gmodena nix-flatpak --rev <rev>
 ```
 
 Example:
+
 ```nix
 let
   # Fetch nix-flatpak
@@ -106,22 +129,26 @@ in
   };
 ```
 
-A minimal config that can be built and tested in a NixOS VM (via `nix-build`) can be found
-at [configuration.nix](https://gist.github.com/gmodena/535f33651db735e39fdb74f7c24a56ac).
+A minimal config that can be built and tested in a NixOS VM (via `nix-build`)
+can be found at
+[configuration.nix](https://gist.github.com/gmodena/535f33651db735e39fdb74f7c24a56ac).
 
 ### Starter config example
-You can find an example configuration in [testing-base/flatpak.nix](https://github.com/gmodena/nix-flatpak/tree/main/testing-base).
 
+You can find an example configuration in
+[testing-base/flatpak.nix](https://github.com/gmodena/nix-flatpak/tree/main/testing-base).
 
 ## Getting Started
 
 Enable flatpak in `configuration.nix`:
+
 ```nix
 services.flatpak.enable = true;
 ```
 
-Import the module (`nixosModules.nix-flatpak` or `homeManagerModules.nix-flatpak`).
-Using flake, installing `nix-flatpak` as a NixOs module would look something like this:
+Import the module (`nixosModules.nix-flatpak` or
+`homeManagerModules.nix-flatpak`). Using flake, installing `nix-flatpak` as a
+NixOs module would look something like this:
 
 ```nix
 {
@@ -140,16 +167,24 @@ Using flake, installing `nix-flatpak` as a NixOs module would look something lik
     };
   };
 }
-
 ```
 
-See [flake.nix](https://github.com/gmodena/nix-flatpak/blob/main/testing-base/flake.nix) in [testing-base](https://github.com/gmodena/nix-flatpak/tree/main/testing-base) for examples of setting up `nix-flatpak` as a NixOs and HomeManager module.
+See
+[flake.nix](https://github.com/gmodena/nix-flatpak/blob/main/testing-base/flake.nix)
+in [testing-base](https://github.com/gmodena/nix-flatpak/tree/main/testing-base)
+for examples of setting up `nix-flatpak` as a NixOs and HomeManager module.
 
-## Notes on HomeManager 
-Depending on how config and inputs are derived `homeManagerModules` import can be flaky. Here's an example of how `homeManagerModules` is imported on my nixos systems config in [modules/home-manager/desktop/nixos/default.nix](https://github.com/gmodena/config/blob/5b3c1ce979881700f9f5ead88f2827f06143512f/modules/home-manager/desktop/nixos/default.nix#L17). `flake-inputs` is a special extra arg set in the repo `flake.nix`
+## Notes on HomeManager
+
+Depending on how config and inputs are derived `homeManagerModules` import can
+be flaky. Here's an example of how `homeManagerModules` is imported on my nixos
+systems config in
+[modules/home-manager/desktop/nixos/default.nix](https://github.com/gmodena/config/blob/5b3c1ce979881700f9f5ead88f2827f06143512f/modules/home-manager/desktop/nixos/default.nix#L17).
+`flake-inputs` is a special extra arg set in the repo `flake.nix`
 [mkNixosConfiguration](https://github.com/gmodena/config/blob/5b3c1ce979881700f9f5ead88f2827f06143512f/flake.nix#L29).
- 
+
 ### Remotes
+
 By default `nix-flatpak` will add the flathub remote. Remotes can be manually
 configured via the `services.flatpak.remotes` option:
 
@@ -158,48 +193,66 @@ services.flatpak.remotes = [{
   name = "flathub-beta"; location = "https://flathub.org/beta-repo/flathub-beta.flatpakrepo";
 }];
 ```
-Note that this declaration will override the default remote config value (`flathub`).
-If you want to keep using `flathub`, you should explicitly declare it in the
-`services.flatpak.remotes` option.
 
-Alternatively, it is possible to merge declared remotes with the default one with `lib.mkDefaultOption`.
+Note that this declaration will override the default remote config value
+(`flathub`). If you want to keep using `flathub`, you should explicitly declare
+it in the `services.flatpak.remotes` option.
+
+Alternatively, it is possible to merge declared remotes with the default one
+with `lib.mkDefaultOption`.
+
 ```nix
-  services.flatpak.remotes = lib.mkOptionDefault [{
-    name = "flathub-beta";
-    location = "https://flathub.org/beta-repo/flathub-beta.flatpakrepo";
-  }];
+services.flatpak.remotes = lib.mkOptionDefault [{
+  name = "flathub-beta";
+  location = "https://flathub.org/beta-repo/flathub-beta.flatpakrepo";
+}];
 ```
 
 ### Packages
+
 Declare packages to install with:
+
 ```nix
-  services.flatpak.packages = [
-    { appId = "com.brave.Browser"; origin = "flathub";  }
-    "com.obsproject.Studio"
-    "im.riot.Riot"
-  ];
+services.flatpak.packages = [
+  { appId = "com.brave.Browser"; origin = "flathub";  }
+  "com.obsproject.Studio"
+  "im.riot.Riot"
+];
 ```
+
 You can pin a specific commit setting `commit=<hash>` attribute.
 
 Rebuild your system (or home-manager) for changes to take place.
 
 #### Flatpakref files
-[Flatpakref](https://docs.flatpak.org/en/latest/repositories.html#flatpakref-files) files can be installed by setting the `flatpakref` attribute to :
+
+[Flatpakref](https://docs.flatpak.org/en/latest/repositories.html#flatpakref-files)
+files can be installed by setting the `flatpakref` attribute to :
+
 ```nix
-  services.flatpak.packages = [
-    { flatpakref = "<uri>"; sha256="<hash>"; }
-  ];
+services.flatpak.packages = [
+  { flatpakref = "<uri>"; sha256="<hash>"; }
+];
 ```
 
-A `sha256` hash is required for  the flatpakref file. This can be generated with `nix-prefetch-url <uri>`.
-Omitting the `sha256` attribute will require an `impure` evaluation of the flake.
+A `sha256` hash is required for the flatpakref file. This can be generated with
+`nix-prefetch-url <uri>`. Omitting the `sha256` attribute will require an
+`impure` evaluation of the flake.
 
-When installing an application from a `flatpakref`, the application remote will be determined as follows:
-1. If the package does not specify an origin, use the remote name suggested by the flatpakref in `SuggestRemoteName`.
-2. If the flatpakref does not suggest a remote name, sanitize the flatpakref `Name` key with the same algo flatpak implements in [create_origin_remote_config()](https://github.com/flatpak/flatpak/blob/b730771bd793b34fb63fcbf292beed35476e5b92/common/flatpak-dir.c#L14423).
+When installing an application from a `flatpakref`, the application remote will
+be determined as follows:
+
+1. If the package does not specify an origin, use the remote name suggested by
+   the flatpakref in `SuggestRemoteName`.
+2. If the flatpakref does not suggest a remote name, sanitize the flatpakref
+   `Name` key with the same algo flatpak implements in
+   [create_origin_remote_config()](https://github.com/flatpak/flatpak/blob/b730771bd793b34fb63fcbf292beed35476e5b92/common/flatpak-dir.c#L14423).
 
 #### Flatpak bundles
-Bundle files (`.flatpak`) can be installed directly by pointing `bundle` at a URI and providing a matching `sha256`:
+
+Bundle files (`.flatpak`) can be installed directly by pointing `bundle` at a
+URI and providing a matching `sha256`:
+
 ```nix
 services.flatpak.packages = [
   rec {
@@ -214,6 +267,7 @@ services.flatpak.packages = [
 ```
 
 You can also install a local bundle from disk:
+
 ```nix
 services.flatpak.packages = [
   {
@@ -226,69 +280,86 @@ services.flatpak.packages = [
 
 ##### Unmanaged packages and remotes
 
-By default `nix-flatpak` will only manage (install/uninstall/update) packages declared in the
-`services.flatpak.packages` and repositories declared in `services.flatpak.remotes`.
-Flatpak packages and repositories installed by the command line of app stores won't be affected.
+By default `nix-flatpak` will only manage (install/uninstall/update) packages
+declared in the `services.flatpak.packages` and repositories declared in
+`services.flatpak.remotes`. Flatpak packages and repositories installed by the
+command line of app stores won't be affected.
 
-Set `services.flatpak.uninstallUnmanaged = true` to alter this behaviour, and have `nix-flatpak` manage the
-lifecycle of all flatpaks packages and repositories.
+Set `services.flatpak.uninstallUnmanaged = true` to alter this behaviour, and
+have `nix-flatpak` manage the lifecycle of all flatpaks packages and
+repositories.
 
-Note that `services.flatpak.uninstallUnmanaged` will only affect a given `system` of `user` installation
-target. If `nix-flatpak` is installed as a HomeManager module all packages/remotes will be managed
-in a `user` installation. Packages/remotes installed system-wide won't be affected
-by `services.flatpak.uninstallUnmanaged`.
+Note that `services.flatpak.uninstallUnmanaged` will only affect a given
+`system` of `user` installation target. If `nix-flatpak` is installed as a
+HomeManager module all packages/remotes will be managed in a `user`
+installation. Packages/remotes installed system-wide won't be affected by
+`services.flatpak.uninstallUnmanaged`.
 
-Similarly, when `nix-flatpak` is installed as a NixOs module, only system-wide config will
-be affected.
+Similarly, when `nix-flatpak` is installed as a NixOs module, only system-wide
+config will be affected.
 
 ### Updates
 
 Set
+
 ```nix
 services.flatpak.update.onActivation = true;
 ```
-to enable updates at system activation. The default is `false`
-so that repeated invocations of `nixos-rebuild switch` are idempotent. Applications 
-pinned to a specific commit hash will not be updated.
 
-Periodic updates can be enabled  by setting:
+to enable updates at system activation. The default is `false` so that repeated
+invocations of `nixos-rebuild switch` are idempotent. Applications pinned to a
+specific commit hash will not be updated.
+
+Periodic updates can be enabled by setting:
+
 ```nix
 services.flatpak.update.auto = {
   enable = true;
   onCalendar = "weekly"; # Default value
 };
 ```
+
 Auto updates trigger on system activation.
 
-Under the hood, updates are scheduled by realtime systemd timers. `onCalendar` accepts systemd's
-`update.auto.onCalendar` expressions. Timers are persisted across sleep / resume cycles.
-See https://wiki.archlinux.org/title/systemd/Timers for more information. 
+Under the hood, updates are scheduled by realtime systemd timers. `onCalendar`
+accepts systemd's `update.auto.onCalendar` expressions. Timers are persisted
+across sleep / resume cycles. See
+https://wiki.archlinux.org/title/systemd/Timers for more information.
 
 ### Storage
-Flatpaks are stored out of nix store at `/var/lib/flatpak` and `${HOME}/.local/share/flatpak/` for system
-(`nixosModules`) and user (`homeManagerModules`) installation respectively. 
-Flatpaks installation are not generational: upon a system rebuild and rollbacks, changes in packages declaration
-will result in downloading applications anew.
 
-Keeping flatpaks and nix store orthogonal is an explicit design choice, dictate by my use cases:
+Flatpaks are stored out of nix store at `/var/lib/flatpak` and
+`${HOME}/.local/share/flatpak/` for system (`nixosModules`) and user
+(`homeManagerModules`) installation respectively. Flatpaks installation are not
+generational: upon a system rebuild and rollbacks, changes in packages
+declaration will result in downloading applications anew.
+
+Keeping flatpaks and nix store orthogonal is an explicit design choice, dictate
+by my use cases:
+
 1. I want to track the latest version of all installed applications.
 2. I am happy to trade network for storage.
 
 YMMV.
 
-If you want an alternative approach with transactional package installation, [declarative-flatpak](https://github.com/in-a-dil-emma/declarative-flatpak)
+If you want an alternative approach with transactional package installation,
+[declarative-flatpak](https://github.com/in-a-dil-emma/declarative-flatpak)
 might be a better fit.
 
 ### Overrides
 
-Flatpak overrides allow you to modify application permissions and environment variables. `nix-flatpak` provides two ways to manage overrides: inline `settings` and external `files`.
+Flatpak overrides allow you to modify application permissions and environment
+variables. `nix-flatpak` provides two ways to manage overrides: inline
+`settings` and external `files`.
 
-**WARNING**: using these settings will overwrite system/user flatpak override files and could cause data loss. Backup
-your files before enabling `.settings` and/or `.files`.
+**WARNING: using these settings will overwrite system/user flatpak override
+files and could cause data loss. Backup your files before enabling `.settings`
+and/or `.files`.**
 
-#### Settings (inline configuration)
+#### Inline configuration
 
-Use `services.flatpak.overrides.settings` to declare overrides directly in your nix configuration:
+Use `services.flatpak.overrides.settings` to declare overrides directly in your
+nix configuration:
 
 ```nix
 {
@@ -322,25 +393,20 @@ Use `services.flatpak.overrides.settings` to declare overrides directly in your 
 }
 ```
 
-**Backwards compatibility:** The legacy  (`nix-flatpak` <= 0.7) format `services.flatpak.overrides = { "app.id" = {...}; }` (without the `.settings` wrapper) is still supported.
+**Backwards compatibility:** The legacy (`nix-flatpak` <= 0.7) format
+`services.flatpak.overrides = { "app.id" = {...}; }` (without the `.settings`
+wrapper) is still supported, but will be removed in the future.
 
-#### Files (external override files)
+#### Eexternal override files
 
-Use `services.flatpak.overrides.files` to load overrides from external files. This is useful for:
-- Sharing override configurations across machines
-- Managing complex overrides separately from your nix configuration
-- Using existing Flatpak override files
+Use `services.flatpak.overrides.files` to load overrides from external INI
+files. This is useful for sharing override configurations across machines,
+managing complex overrides separately from your nix configuration and/or using
+existing Flatpak override files. See
+[https://github.com/gmodena/nix-flatpak/issues/82][!82].
 
-```nix
-{
-  services.flatpak.overrides.files = [
-    "/path/to/overrides.d/com.visualstudio.code"
-    "/path/to/overrides.d/org.gnome.Terminal"
-  ];
-}
-```
-
-The file name must match the application ID (e.g., `com.visualstudio.code`). Files should be in standard Flatpak override INI format:
+The file name must match the application ID (e.g., `com.visualstudio.code`).
+Files should be in standard Flatpak override INI format:
 
 ```ini
 [Context]
@@ -352,7 +418,9 @@ GTK_THEME=Adwaita:dark
 
 #### Combining settings and files
 
-When both `settings` and `files` are specified for the same application, they are merged. Values from `settings` take precedence over values from `files`, and both are merged with any externally applied overrides already on disk.
+When both `settings` and `files` are specified for the same application, they
+are merged. Values from `settings` take precedence over values from `files`, and
+both are merged with any externally applied overrides already on disk.
 
 ```nix
 {
@@ -366,31 +434,107 @@ When both `settings` and `files` are specified for the same application, they ar
 }
 ```
 
-#### Deleting orphaned override files
+#### Write mode
 
-**Bugs of incorrect use of this option can result in data loss Make sure your overrides are backed up before enabling this option.**
+The `writeMode` option controls how `nix-flatpak` writes override files to disk.
+It accepts two values:
 
-By default, when you remove an override from your nix configuration, the corresponding file in the flatpak overrides directory is preserved on disk. This behaviour is controlled by the `deleteOrphanedFiles` option:
+- `"merge"` (default): at activation time, existing override files on disk are
+  read and merged with the nix-managed settings. Direct user edits to keys not
+  declared in nix are preserved across generations.
+- `"replace"`: the complete override file for each application is computed at
+  evaluation time as a pure store derivation. At activation time the precomputed
+  file is copied to the overrides directory. `nix-flatpak` fully owns the file.
+  Any direct user edits are overwritten on the next activation.
 
 ```nix
 {
-  services.flatpak.overrides.deleteOrphanedFiles = false; # Default
+  services.flatpak.overrides.writeMode = "merge";   # default
 }
 ```
 
-| `deleteOrphanedFiles` | Override removed from config | Result |
-|-----------------------|------------------------------|--------|
-| `false` (default)     | Yes                          | Override file **preserved** on disk |
-| `true`                | Yes                          | Override file **deleted** from disk |
+##### Evaluation
 
-When `deleteOrphanedFiles = true`, nix-flatpak scans the actual overrides directory and removes any files that are not declared in the current configuration (either in `settings` or `files`). This ensures a clean state where only managed overrides exist.
+When `overrides.files` contains plain string paths (paths outside the Nix
+store), `nix-flatpak` must read them from the filesystem at evaluation time,
+which is an impure operation. This applies to both write modes, because the
+state file always parses `overrides.files` at eval time regardless of
+`writeMode`.
 
-If you previously had `deleteOrphanedFiles = false`, swithing to `deleteOrphanedFiles = true` will delete all override files removed from the current config, that where present in the previous generation. If override files accumulated over previous generations, a manual cleanup of all unmanaged files will be necessary.
+Such configurations require passing `--impure` to `nixos-rebuild`:
+
+```nix
+{
+  services.flatpak.overrides = {
+    files = [
+      "/home/user/dotfiles/overrides/com.visualstudio.code" 
+    ];
+  };
+}
+```
+
+```bash
+sudo nixos-rebuild switch --impure
+```
+
+To avoid `--impure`, use Nix path literals instead of strings for
+`overrides.files`. Path literals are copied into the Nix store during
+evaluation, making the entire configuration reproducible:
+
+```nix
+{
+  services.flatpak.overrides = {
+    files = [
+      ./overrides/com.visualstudio.code
+      ./overrides/org.gnome.Terminal
+    ];
+  };
+}
+```
+
+With `writeMode = "replace"` and store-path files, the merged override content
+for each application is fully determined at evaluation time. No reading of
+on-disk override files occurs at activation. This is the most reproducible
+configuration.
+
+Note: `writeMode = "replace"` with only `settings` (no `files`) is always pure
+and never requires `--impure`.
+
+#### Deleting orphaned override files
+
+**Bugs of incorrect use of this option can result in data loss. Make sure your
+overrides are backed up before enabling this option.**
+
+By default, when you remove an override from your nix configuration, the
+corresponding file in the flatpak overrides directory is preserved on disk. This
+behaviour is controlled by the `pruneUnmanagedOverrides` option:
+
+```nix
+{
+  services.flatpak.overrides.pruneUnmanagedOverrides = false; # Default
+}
+```
+
+When `pruneUnmanagedOverrides = true`, nix-flatpak scans the actual overrides
+directory and removes any files that are not declared in the current
+configuration (either in `settings` or `files`). This ensures a clean state
+where only managed overrides exist.
+
+If you previously had `pruneUnmanagedOverrides = false`, switching to
+`pruneUnmanagedOverrides = true` will delete all override files removed from the
+current config that were present in the previous generation. If override files
+accumulated over previous generations, a manual cleanup of all unmanaged files
+will be necessary.
 
 ### Systemd unit retry on error
-On flaky network connections the `nix-flatpak` installer script may fail. 
 
-The `restartOnFailure` option controls the behavior of the flatpak-managed-install service when it encounters a failure. As of 0.6.0 it is enabled by default, and wraps systemd APIs. It's configuration can be modified by setting:
+On flaky network connections the `nix-flatpak` installer script may fail.
+
+The `restartOnFailure` option controls the behavior of the
+flatpak-managed-install service when it encounters a failure. As of 0.6.0 it is
+enabled by default, and wraps systemd APIs. It's configuration can be modified
+by setting:
+
 ```nix
 restartOnFailure = {
   enable = true;
@@ -411,13 +555,20 @@ A couple of things to be aware of when working with `nix-flatpak`.
 
 ## Infinite recursion in home-manager imports
 
-Users have reported an infinite recursion stacktrace when importing an home-manager module outside of where home-manager
-itself was imported.
+Users have reported an infinite recursion stacktrace when importing an
+home-manager module outside of where home-manager itself was imported.
 
-To work around this issue, you should avoid nesting home-manager modules. This means that when you are structuring your configuration, make sure that you do not have home-manager modules imported within each other in a way that could lead to circular imports.
+To work around this issue, you should avoid nesting home-manager modules. This
+means that when you are structuring your configuration, make sure that you do
+not have home-manager modules imported within each other in a way that could
+lead to circular imports.
 
-You can follow the discussions and updates on issue [#25](https://github.com/gmodena/nix-flatpak/issues/25) to stay informed about any resolutions or workarounds.
+You can follow the discussions and updates on issue
+[#25](https://github.com/gmodena/nix-flatpak/issues/25) to stay informed about
+any resolutions or workarounds.
 
 ## Q&A and support
 
-For further support questions and common issues on how to integrate and set up `nix-flatpak` on your system, please consult the [Q&A discussions page](https://github.com/gmodena/nix-flatpak/discussions/categories/q-a).
+For further support questions and common issues on how to integrate and set up
+`nix-flatpak` on your system, please consult the
+[Q&A discussions page](https://github.com/gmodena/nix-flatpak/discussions/categories/q-a).

--- a/README.md
+++ b/README.md
@@ -281,10 +281,15 @@ might be a better fit.
 
 ### Overrides
 
-Package overrides can be declared via `services.flatpak.overrides`. Following is a usage example:
+Flatpak overrides allow you to modify application permissions and environment variables. `nix-flatpak` provides two ways to manage overrides: inline `settings` and external `files`.
+
+#### Settings (inline configuration)
+
+Use `services.flatpak.overrides.settings` to declare overrides directly in your nix configuration:
+
 ```nix
 {
-  services.flatpak.overrides = {
+  services.flatpak.overrides.settings = {
     global = {
       # Force Wayland by default
       Context.sockets = ["wayland" "!x11" "!fallback-x11"];
@@ -313,6 +318,69 @@ Package overrides can be declared via `services.flatpak.overrides`. Following is
   };
 }
 ```
+
+**Backwards compatibility:** The legacy format `services.flatpak.overrides = { "app.id" = {...}; }` (without the `.settings` wrapper) is still supported.
+
+#### Files (external override files)
+
+Use `services.flatpak.overrides.files` to load overrides from external files. This is useful for:
+- Sharing override configurations across machines
+- Managing complex overrides separately from your nix configuration
+- Using existing Flatpak override files
+
+```nix
+{
+  services.flatpak.overrides.files = [
+    "/path/to/overrides.d/com.visualstudio.code"
+    "/path/to/overrides.d/org.gnome.Terminal"
+  ];
+}
+```
+
+The file name must match the application ID (e.g., `com.visualstudio.code`). Files should be in standard Flatpak override INI format:
+
+```ini
+[Context]
+sockets=wayland;!x11;
+
+[Environment]
+GTK_THEME=Adwaita:dark
+```
+
+#### Combining settings and files
+
+When both `settings` and `files` are specified for the same application, they are merged. Values from `settings` take precedence over values from `files`, and both are merged with any externally applied overrides already on disk.
+
+```nix
+{
+  services.flatpak.overrides = {
+    # Base configuration from file
+    files = [ "/path/to/overrides.d/com.visualstudio.code" ];
+
+    # Additional settings merged on top
+    settings."com.visualstudio.code".Context.sockets = ["gpg-agent"];
+  };
+}
+```
+
+#### Deleting orphaned override files
+
+By default, when you remove an override from your nix configuration, the corresponding file in the flatpak overrides directory is preserved on disk. This behaviour is controlled by the `deleteOrphanedFiles` option:
+
+```nix
+{
+  services.flatpak.overrides.deleteOrphanedFiles = false; # Default
+}
+```
+
+| `deleteOrphanedFiles` | Override removed from config | Result |
+|-----------------------|------------------------------|--------|
+| `false` (default)     | Yes                          | Override file **preserved** on disk |
+| `true`                | Yes                          | Override file **deleted** from disk |
+
+When `deleteOrphanedFiles = true`, nix-flatpak scans the actual overrides directory and removes any files that are not declared in the current configuration (either in `settings` or `files`). This ensures a clean state where only managed overrides exist.
+
+**Note:** If you previously had `deleteOrphanedFiles = false` and orphaned files accumulated on disk, switching to `deleteOrphanedFiles = true` will delete all unmanaged override files on the next activation.
 
 ### Systemd unit retry on error
 On flaky network connections the `nix-flatpak` installer script may fail. 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,8 @@ When both `settings` and `files` are specified for the same application, they ar
 
 #### Deleting orphaned override files
 
+**Bugs of incorrect use of this option can result in data loss Make sure your overrides are backed up before enabling this option.**
+
 By default, when you remove an override from your nix configuration, the corresponding file in the flatpak overrides directory is preserved on disk. This behaviour is controlled by the `deleteOrphanedFiles` option:
 
 ```nix
@@ -383,7 +385,7 @@ By default, when you remove an override from your nix configuration, the corresp
 
 When `deleteOrphanedFiles = true`, nix-flatpak scans the actual overrides directory and removes any files that are not declared in the current configuration (either in `settings` or `files`). This ensures a clean state where only managed overrides exist.
 
-**Note:** If you previously had `deleteOrphanedFiles = false` and orphaned files accumulated on disk, switching to `deleteOrphanedFiles = true` will delete all unmanaged override files on the next activation.
+If you previously had `deleteOrphanedFiles = false`, swithing to `deleteOrphanedFiles = true` will delete all override files removed from the current config, that where present in the previous generation. If override files accumulated over previous generations, a manual cleanup of all unmanaged files will be necessary.
 
 ### Systemd unit retry on error
 On flaky network connections the `nix-flatpak` installer script may fail. 

--- a/README.md
+++ b/README.md
@@ -526,6 +526,36 @@ current config that were present in the previous generation. If override files
 accumulated over previous generations, a manual cleanup of all unmanaged files
 will be necessary.
 
+#### Downgrading to a release prior to v2 state format
+
+`nix-flatpak` uses an internal state file to track managed overrides across
+activations. Releases `> 0.7.0` support `overrides.settings` and
+`overrides.files` write a v2 state file. If you downgrade to an older release
+that only understands the v1 flat `overrides` format, the older release will
+misinterpret its meta-keys (`settings`, `files`, `_fileSettings`,
+`pruneUnmanagedOverrides`, `writeMode`) as Flatpak app ids.
+
+On the first activation after the downgrade, the older release will create
+spurious override files with those names in your flatpak overrides directory
+(`/var/lib/flatpak/overrides` or `~/.local/share/flatpak/overrides`). These
+files have no effect (Flatpak ignores filenames that are not valid
+reverse-domain app IDs) but they are left on disk as clutter.
+
+**Your real app override files are not affected.** To clean up the stray files,
+run:
+
+```bash
+# For a user (home-manager) installation
+for name in settings files _fileSettings pruneUnmanagedOverrides writeMode; do
+  rm -f "${XDG_DATA_HOME:-$HOME/.local/share}/flatpak/overrides/$name"
+done
+
+# For a system (NixOS) installation
+for name in settings files _fileSettings pruneUnmanagedOverrides writeMode; do
+  sudo rm -f "/var/lib/flatpak/overrides/$name"
+done
+```
+
 ### Systemd unit retry on error
 
 On flaky network connections the `nix-flatpak` installer script may fail.

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -30,7 +30,7 @@ rec {
   # files that were written by an older version of nix-flatpak and have not yet been migrated.
   hasLegacyOverrides = cfg:
     let
-      newFormatKeys = [ "settings" "files" "deleteOrphanedFiles" ];
+      newFormatKeys = [ "settings" "files" "pruneUnmanagedOverrides" "writeMode" ];
       overrideKeys = builtins.attrNames (cfg.overrides or {});
       legacyKeys = builtins.filter (k: !(builtins.elem k newFormatKeys)) overrideKeys;
     in

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -23,8 +23,20 @@ rec {
     Persistent = "true";
   };
 
+  # Detect legacy overrides format (settings directly under `overrides` instead of `overrides.settings`)
+  hasLegacyOverrides = cfg:
+    let
+      newFormatKeys = [ "settings" "files" "deleteOrphanedFiles" ];
+      overrideKeys = builtins.attrNames (cfg.overrides or {});
+      legacyKeys = builtins.filter (k: !(builtins.elem k newFormatKeys)) overrideKeys;
+    in
+    legacyKeys != [];
+
   warnDeprecated = cfg:
     lib.warnIf (! isNull cfg.uninstallUnmanagedPackages)
       "uninstallUnmanagedPackages is deprecated since nix-flatpak 0.4.0 and will be removed in 1.0.0. Use uninstallUnmanaged instead."
-      cfg;
+    (lib.warnIf (hasLegacyOverrides cfg)
+      "Use 'services.flatpak.overrides.settings' instead of 'services.flatpak.overrides' for app overrides. Direct
+      `overrides` configuration is deprecated and will be removed in future nix-flatpak versions."
+      cfg);
 }

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -23,7 +23,11 @@ rec {
     Persistent = "true";
   };
 
-  # Detect legacy overrides format (settings directly under `overrides` instead of `overrides.settings`)
+  # Detect legacy overrides format (settings directly under `overrides` instead of `overrides.settings`).
+  # Note: since the `overrides` option now uses `coercedTo`, freshly-evaluated NixOS/home-manager
+  # configs will always arrive here in the new submodule shape. Coercion normalises the legacy format
+  # before it reaches this function. This check therefore only fires when reading legacy JSON state
+  # files that were written by an older version of nix-flatpak and have not yet been migrated.
   hasLegacyOverrides = cfg:
     let
       newFormatKeys = [ "settings" "files" "deleteOrphanedFiles" ];

--- a/modules/flatpak/ini.nix
+++ b/modules/flatpak/ini.nix
@@ -1,0 +1,108 @@
+{lib}: let
+  trimStr = s: let
+    m = builtins.match "[[:space:]]*(.*[^[:space:]]|)[[:space:]]*" s;
+  in
+    if m == null
+    then ""
+    else builtins.elemAt m 0;
+
+  # Parse a flatpak INI file into a nix attrset with the same shape as
+  # overrides.settings:
+  #
+  #   { SectionName = { key = string_or_list; ... }; ... }
+  #
+  # - Keys and values are whitespace-trimmed.
+  # - Semicolon-separated values become a list; single values stay as a string.
+  # - Blank lines and lines starting with '#' or ';' are ignored.
+  parseIniContent = content: let
+    lines = lib.splitString "\n" content;
+  in
+    (builtins.foldl' (
+        acc: rawLine: let
+          line = trimStr rawLine;
+          isComment = lib.hasPrefix "#" line || lib.hasPrefix ";" line;
+          isEmpty = line == "";
+          isSection =
+            !isComment
+            && !isEmpty
+            && lib.hasPrefix "[" line
+            && lib.hasSuffix "]" line;
+          sectionName = lib.removeSuffix "]" (lib.removePrefix "[" line);
+          kvMatch = builtins.match "^([^=]+)=(.*)$" line;
+          isKV = kvMatch != null && !isSection;
+          key = trimStr (builtins.elemAt kvMatch 0);
+          rawValue = trimStr (builtins.elemAt kvMatch 1);
+          values = builtins.filter (s: s != "") (lib.splitString ";" rawValue);
+          parsedValue =
+            if builtins.length values > 1
+            then values
+            else rawValue;
+        in
+          if isSection
+          then acc // {section = sectionName;}
+          else if isKV && acc.section != null
+          then
+            acc
+            // {
+              sections =
+                acc.sections
+                // {
+                  ${acc.section} =
+                    (acc.sections.${acc.section} or {})
+                    // {
+                      ${key} = parsedValue;
+                    };
+                };
+            }
+          else acc
+      ) {
+        section = null;
+        sections = {};
+      }
+      lines).sections;
+
+  # Serialize a nix attrset (overrides.settings shape) back to flatpak INI format.
+  # Sections and keys are emitted in alphabetical order; list values are joined with ';'.
+  toIniContent = attrs: let
+    sections = builtins.sort (a: b: a < b) (builtins.attrNames attrs);
+    renderValue = v:
+      if builtins.isList v
+      then builtins.concatStringsSep ";" v
+      else v;
+    renderEntry = section: key: "${key}=${renderValue attrs.${section}.${key}}";
+    renderSection = section: let
+      keys = builtins.sort (a: b: a < b) (builtins.attrNames attrs.${section});
+    in
+      "[${section}]\n" + builtins.concatStringsSep "\n" (map (renderEntry section) keys) + "\n";
+  in
+    builtins.concatStringsSep "\n" (map renderSection sections);
+  # Merge two parsed INI attrsets (eg. `settings` and `fileSettings`) for a single appId.
+  # `settings` wins over `fileSettings` for any key present in both.
+  # Returns a merged attrset in the same shape as `overrides.settings`.
+  mergeOverrideSettings = settings: fileSettingsByApp: appId: let
+    s = settings.${appId} or {};
+    f = fileSettingsByApp.${appId} or {};
+    sections = lib.lists.unique (builtins.attrNames s ++ builtins.attrNames f);
+    mergedSection = sec: let
+      allKeys = lib.lists.unique (
+        builtins.attrNames (s.${sec} or {})
+        ++ builtins.attrNames (f.${sec} or {})
+      );
+    in
+      builtins.listToAttrs (map (k: {
+          name = k;
+          value =
+            if s ? ${sec} && s.${sec} ? ${k}
+            then s.${sec}.${k}
+            else f.${sec}.${k};
+        })
+        allKeys);
+  in
+    builtins.listToAttrs (map (sec: {
+        name = sec;
+        value = mergedSection sec;
+      })
+      sections);
+in {
+  inherit parseIniContent toIniContent mergeOverrideSettings;
+}

--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -12,7 +12,7 @@ let
     (builtins.filter (package: utils.isFlatpakref package) cfg.packages);
 
   # We use an incremental versioning scheme for the state file. For internal use only.
-  formatVersion = 1;
+  formatVersion = 2;
 
   # Put the state file in the `gcroots` folder of the respective installation,
   # which prevents it from being garbage collected. This could probably be
@@ -25,10 +25,14 @@ let
   # {
   #   "packages": ["org.gnome.Epiphany", "org.gnome.Epiphany.Devel"],
   #   "overrides": {
-  #     "org.gnome.Epiphany": {
-  #       "command": "env MOZ_ENABLE_WAYLAND=1 /run/current-system/sw/bin/epiphany",
-  #       "env": "MOZ_ENABLE_WAYLAND=1"
-  #     }
+  #      "settings": {
+  #         "org.gnome.Epiphany": {
+  #           "command": "env MOZ_ENABLE_WAYLAND=1 /run/current-system/sw/bin/epiphany",
+  #           "env": "MOZ_ENABLE_WAYLAND=1"
+  #         },
+  #       },
+  #      "files": [],
+  #      "settingsFiles": []
   #   },
   #   "remotes": ["flathub", "gnome-nightly"]
   # }

--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -161,7 +161,7 @@ let
     builtins.map (path: {
       name = builtins.baseNameOf path; 
       value = path;                     
-    }) cfg.overridesFiles
+    }) cfg.overrides.files
   );
 
   flatpakOverridesCmd = installation: {}: ''
@@ -171,7 +171,7 @@ let
       --argjson old "$OLD_STATE" \
       --argjson new "$NEW_STATE" \
       --argjson override_files '${builtins.toJSON overrideFiles}' \
-      '[(($new.overrides + $old.overrides | keys[]), ($override_files | keys[]))] | unique[]' \
+      '[(((try $new.overrides.settings catch $new.overrides) + (try $old.overrides.settings catch $old.overrides) | keys[]), ($override_files | keys[]))] | unique[]' \
       | while read -r APP_ID; do
         OVERRIDES_PATH=${overridesDir}/$APP_ID
 

--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -281,23 +281,30 @@ let
           >$OVERRIDES_PATH
       done
 
-    # Delete orphaned override files when deleteOrphanedFiles mode is enabled
-    # Scan actual disk to catch files that were orphaned before deleteOrphanedFiles was enabled
+    # Delete override files that were previously managed by nix-flatpak but have since been removed from configuration.
     ${lib.optionalString (cfg.overrides.deleteOrphanedFiles or false) ''
       if [[ -d "${overridesDir}" ]]; then
         for OVERRIDE_FILE in "${overridesDir}"/*; do
           [[ -f "$OVERRIDE_FILE" ]] || continue
           APP_ID=$(${pkgs.coreutils}/bin/basename "$OVERRIDE_FILE")
 
+          # Check if this app was previously managed by nix-flatpak (in old state)
+          OVERRIDES_WAS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
+            --arg app_id "$APP_ID" \
+            --argjson old "$OLD_STATE" \
+            '(($old.overrides.settings[$app_id] // $old.overrides[$app_id]) != null) or
+             ($old.overrides.files // [] | map(split("/") | last) | index($app_id) != null)')
+
           # Check if this app is managed in current config (settings or files)
-          IS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
+          OVERRIDES_IS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
             --arg app_id "$APP_ID" \
             --argjson new "$NEW_STATE" \
             --argjson override_files '${builtins.toJSON overrideFiles}' \
             '(($new.overrides.settings[$app_id] // $new.overrides[$app_id]) != null) or
              ($override_files[$app_id] != null)')
 
-          if [[ "$IS_MANAGED" == "false" ]]; then
+          # Only delete if it was ours and we've stopped managing it
+          if [[ "$OVERRIDES_WAS_MANAGED" == "true" && "$OVERRIDES_IS_MANAGED" == "false" ]]; then
             ${pkgs.coreutils}/bin/rm -f "$OVERRIDE_FILE"
           fi
         done

--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -166,9 +166,9 @@ let
 
   overrideFiles = builtins.listToAttrs (
     builtins.map (path: {
-      name = builtins.baseNameOf path; 
-      value = path;                     
-    }) cfg.overrides.files
+      name = builtins.baseNameOf path;
+      value = path;
+    }) (cfg.overrides.files or [])
   );
 
   flatpakOverridesCmd = installation: {}: ''
@@ -178,7 +178,7 @@ let
       --argjson old "$OLD_STATE" \
       --argjson new "$NEW_STATE" \
       --argjson override_files '${builtins.toJSON overrideFiles}' \
-      '[(((try $new.overrides.settings catch $new.overrides) + (try $old.overrides.settings catch $old.overrides) | keys[]),
+      '[((($new.overrides.settings // $new.overrides) + ($old.overrides.settings // $old.overrides) | keys[]),
         ($override_files | keys[]),
         ($old.overrides.files // [] | map(split("/") | last) | .[]))] | unique[]' \
       | while read -r APP_ID; do
@@ -203,13 +203,13 @@ let
           --arg app_id "$APP_ID" \
           --argjson new "$NEW_STATE" \
           --argjson override_files '${builtins.toJSON overrideFiles}' \
-          '((try $new.overrides.settings[$app_id] catch $new.overrides[$app_id]) != null) or
+          '(($new.overrides.settings[$app_id] // $new.overrides[$app_id]) != null) or
            ($override_files[$app_id] != null)')
 
         # Skip orphaned apps when deleteOrphanedFiles=false
         # (apps only from removed files with no new configuration)
         if [[ "$WAS_FILE_REMOVED" == "true" && "$HAS_NEW_CONFIG" == "false" ]]; then
-          ${if cfg.overrides.deleteOrphanedFiles then ":" else "continue"}
+          ${if (cfg.overrides.deleteOrphanedFiles or false) then ":" else "continue"}
         fi
 
         # Read the base file from overrideFiles and convert to JSON (if file exists)
@@ -247,7 +247,7 @@ let
 
     # Delete orphaned override files when deleteOrphanedFiles mode is enabled
     # Scan actual disk to catch files that were orphaned before deleteOrphanedFiles was enabled
-    ${lib.optionalString cfg.overrides.deleteOrphanedFiles ''
+    ${lib.optionalString (cfg.overrides.deleteOrphanedFiles or false) ''
       if [[ -d "${overridesDir}" ]]; then
         for OVERRIDE_FILE in "${overridesDir}"/*; do
           [[ -f "$OVERRIDE_FILE" ]] || continue
@@ -258,7 +258,7 @@ let
             --arg app_id "$APP_ID" \
             --argjson new "$NEW_STATE" \
             --argjson override_files '${builtins.toJSON overrideFiles}' \
-            '((try $new.overrides.settings[$app_id] catch $new.overrides[$app_id]) != null) or
+            '(($new.overrides.settings[$app_id] // $new.overrides[$app_id]) != null) or
              ($override_files[$app_id] != null)')
 
           if [[ "$IS_MANAGED" == "false" ]]; then

--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -164,12 +164,48 @@ let
     then "/var/lib/flatpak/overrides"
     else "\${XDG_DATA_HOME:-$HOME/.local/share}/flatpak/overrides";
 
-  overrideFiles = builtins.listToAttrs (
-    builtins.map (path: {
-      name = builtins.baseNameOf path;
-      value = path;
-    }) (cfg.overrides.files or [])
-  );
+  overrideFiles =
+    let
+      files = cfg.overrides.files or [];
+
+      # Flatpak uses the basename of each override file as the appId key (e.g. "com.example.App").
+      # If two paths share the same basename, builtins.listToAttrs would silently drop one of them
+      # with no indication of which was kept. We detect this early and fail with a clear message
+      # so the user can fix their configuration before it causes confusing runtime behaviour.
+      basenames = map builtins.baseNameOf files;
+      duplicates = lib.lists.unique (
+        builtins.filter
+          (name: builtins.length (builtins.filter (n: n == name) basenames) > 1)
+          basenames
+      );
+
+      # Paths flow through jq into a shell `cat "$OVERRIDE_FILE"` invocation.
+      # Newlines and null bytes corrupt the `while read` loop that
+      # iterates over appIds, and single quotes can break out of jq's single-quoted
+      # string literals. Reject these at evaluation time so they never reach the
+      # generated shell script.
+      # TODO(gmodena, 2026-04): this list is expected to grow.
+      invalidChars = [ "\n" "\r" "\x00" "'" ];
+      hasInvalidChar = path: builtins.any (c: lib.strings.hasInfix c path) invalidChars;
+      invalidPaths = builtins.filter hasInvalidChar files;
+    in
+    if invalidPaths != []
+    then throw ''
+      services.flatpak.overrides.files: the following paths contain invalid characters: ${builtins.toJSON invalidPaths}
+    ''
+    else if duplicates != []
+    then throw ''
+      services.flatpak.overrides.files: duplicate override file basenames detected: ${builtins.concatStringsSep ", " duplicates}.
+      Flatpak uses the basename as the app ID key; each path must have a unique basename.
+      Conflicting paths: ${builtins.toJSON files}
+    ''
+    else
+      builtins.listToAttrs (
+        builtins.map (path: {
+          name = builtins.baseNameOf path;
+          value = path;
+        }) files
+      );
 
   flatpakOverridesCmd = installation: {}: ''
     # Update overrides that are managed by this module (both old and new)

--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -1,20 +1,28 @@
-{ cfg, pkgs, lib, installation ? "system", executionContext ? "service-start", ... }:
+{
+  cfg,
+  pkgs,
+  lib,
+  installation ? "system",
+  executionContext ? "service-start",
+  ...
+}: let
+  utils = import ./ref.nix {inherit lib;};
+  remotes = import ./remotes.nix {inherit pkgs;};
+  ini = import ./ini.nix {inherit lib;};
 
-let
-  utils = import ./ref.nix { inherit lib; };
-  remotes = import ./remotes.nix { inherit pkgs; };
-
-  flatpakrefCache = builtins.foldl'
-    (acc: package:
-      acc // utils.flatpakrefToAttrSet package acc
+  flatpakrefCache =
+    builtins.foldl'
+    (
+      acc: package:
+        acc // utils.flatpakrefToAttrSet package acc
     )
-    { }
+    {}
     (builtins.filter (package: utils.isFlatpakref package) cfg.packages);
 
   # We use an incremental versioning scheme for the state file. For internal use only.
   # none. legacy state management
   # 1. Initial state object format. Store package and remotes attrsets instead of just keys.
-  # 2. Added support of `overrides.settings` and `overrides.files` attrs.
+  # 2. Added support of `overrides.settings`, `overrides.files`, `overrides.fileSettings` attrs.
   formatVersion = 2;
 
   # Put the state file in the `gcroots` folder of the respective installation,
@@ -34,8 +42,10 @@ let
   #           "env": "MOZ_ENABLE_WAYLAND=1"
   #         },
   #       },
-  #      "files": [],
-  #      "settingsFiles": []
+  #      "files": ["/path/to/overrides.d/org.gnome.gedit"],
+  #      "_fileSettings": {
+  #        "org.gnome.gedit": { "Context": { "sockets": ["wayland", "!x11"] } }
+  #      }
   #   },
   #   "remotes": ["flathub", "gnome-nightly"]
   # }
@@ -46,46 +56,55 @@ let
 
   stateFile = pkgs.writeText "flatpak-state.json" (builtins.toJSON {
     version = formatVersion;
-    packages = map
-      (package:
-        let
-          appId =
-            if utils.isFlatpakref package
-            then flatpakrefCache.${(utils.sanitizeUrl package.flatpakref)}.Name
-            else package.appId;
-          origin = if utils.isFlatpakref package
-            then utils.getRemoteNameFromFlatpakref null flatpakrefCache.${utils.sanitizeUrl package.flatpakref}
-            else package.origin;
-        in
-        {
-          appId = appId;
-          origin = origin;
-          flatpakref = package.flatpakref or null;
-          commit = package.commit or null;
-          bundle = package.bundle;
-          sha256 = package.sha256;
-        })
+    packages =
+      map
+      (package: let
+        appId =
+          if utils.isFlatpakref package
+          then flatpakrefCache.${(utils.sanitizeUrl package.flatpakref)}.Name
+          else package.appId;
+        origin =
+          if utils.isFlatpakref package
+          then utils.getRemoteNameFromFlatpakref null flatpakrefCache.${utils.sanitizeUrl package.flatpakref}
+          else package.origin;
+      in {
+        appId = appId;
+        origin = origin;
+        flatpakref = package.flatpakref or null;
+        commit = package.commit or null;
+        bundle = package.bundle;
+        sha256 = package.sha256;
+      })
       cfg.packages;
-    overrides = cfg.overrides;
+    overrides =
+      cfg.overrides
+      // {
+        _fileSettings =
+          builtins.mapAttrs
+          (_: path: ini.parseIniContent (builtins.readFile (builtins.toPath path)))
+          overrideFiles;
+      };
     # Iterate over remotes and handle remotes installed from flatpakref URLs
     remotes =
       # Existing remotes (not from flatpakref)
       (map
-        (remote:
-          let name = remote.name;
-          in { name = name; }
+        (
+          remote: let
+            name = remote.name;
+          in {name = name;}
         )
         cfg.remotes)
       ++
       # Add remotes extracted from flatpakref URLs in packages.
       (map
-        (remote:
-          { name = remote; }
+        (
+          remote: {name = remote;}
         )
         (builtins.filter (remote: !builtins.isNull remote)
           (map
-            (package:
-              utils.getRemoteNameFromFlatpakref null flatpakrefCache.${utils.sanitizeUrl package.flatpakref}
+            (
+              package:
+                utils.getRemoteNameFromFlatpakref null flatpakrefCache.${utils.sanitizeUrl package.flatpakref}
             )
             (builtins.filter (package: utils.isFlatpakref package) cfg.packages))));
   });
@@ -95,29 +114,25 @@ let
   # Get the appId and origin from a flatpakref file or URL to pass to flatpak commands.
   # As of 2024-10 Flatpak will fail to reinstall from flatpakref URL (https://github.com/flatpak/flatpak/issues/5460).
   # This function will return the appId if the package is already installed, otherwise it will return the flatpakref URL.
-  installOrUpdateFromFlatpakref = flatpakrefUrl: installation:
-    let
-      appId = flatpakrefCache.${(utils.sanitizeUrl flatpakrefUrl)}.Name;
-      origin = utils.getRemoteNameFromFlatpakref null flatpakrefCache.${(utils.sanitizeUrl flatpakrefUrl)};
-    in
-    ''
-      $(if ${pkgs.flatpak}/bin/flatpak --${installation} list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q ${appId}; then
-          echo "${origin} ${appId}"
-      else
-          echo "--from ${flatpakrefUrl}"
-      fi)
-    '';
+  installOrUpdateFromFlatpakref = flatpakrefUrl: installation: let
+    appId = flatpakrefCache.${(utils.sanitizeUrl flatpakrefUrl)}.Name;
+    origin = utils.getRemoteNameFromFlatpakref null flatpakrefCache.${(utils.sanitizeUrl flatpakrefUrl)};
+  in ''
+    $(if ${pkgs.flatpak}/bin/flatpak --${installation} list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q ${appId}; then
+        echo "${origin} ${appId}"
+    else
+        echo "--from ${flatpakrefUrl}"
+    fi)
+  '';
 
   # Install or update a flatpak bundle.
-  installOrUpdateFromBundle = path: appId: oldSha256: newSha256:
-    let
-      path = path;
-      appId = appId;
-      needsUpdate = oldSha256 != newSha256;
-    in
-    ''
-      ${appId}
-    '';
+  installOrUpdateFromBundle = path: appId: oldSha256: newSha256: let
+    path = path;
+    appId = appId;
+    needsUpdate = oldSha256 != newSha256;
+  in ''
+    ${appId}
+  '';
 
   # This script is used to manage the lifecyle of all flatpaks (remotes, packages)
   # installed on the system.
@@ -131,7 +146,7 @@ let
       # Add all installed remotes to the old state, so that only managed (= declared in nix-flatpak's config)
       # ones will be kept across generations.
       INSTALLED_REMOTES=$(${pkgs.flatpak}/bin/flatpak --${installation} remotes --columns=name)
-      
+
       # Add unmanaged packages and remotes to old state.
       OLD_STATE=$(${pkgs.jq}/bin/jq -r -n \
         --argjson old "$OLD_STATE" \
@@ -164,99 +179,111 @@ let
     then "/var/lib/flatpak/overrides"
     else "\${XDG_DATA_HOME:-$HOME/.local/share}/flatpak/overrides";
 
-  overrideFiles =
-    let
-      files = cfg.overrides.files or [];
+  overrideFiles = let
+    files = cfg.overrides.files or [];
 
-      # Flatpak uses the basename of each override file as the appId key (e.g. "com.example.App").
-      # If two paths share the same basename, builtins.listToAttrs would silently drop one of them
-      # with no indication of which was kept. We detect this early and fail with a clear message
-      # so the user can fix their configuration before it causes confusing runtime behaviour.
-      basenames = map builtins.baseNameOf files;
-      duplicates = lib.lists.unique (
-        builtins.filter
-          (name: builtins.length (builtins.filter (n: n == name) basenames) > 1)
-          basenames
-      );
+    # Flatpak uses the basename of each override file as the appId key (e.g. "com.example.App").
+    # If two paths share the same basename, builtins.listToAttrs would silently drop one of them
+    # with no indication of which was kept. We detect this early and fail with a clear message
+    # so the user can fix their configuration before it causes confusing runtime behaviour.
+    basenames = map builtins.baseNameOf files;
+    duplicates = lib.lists.unique (
+      builtins.filter
+      (name: builtins.length (builtins.filter (n: n == name) basenames) > 1)
+      basenames
+    );
 
-      # Paths flow through jq into a shell `cat "$OVERRIDE_FILE"` invocation.
-      # Newlines and null bytes corrupt the `while read` loop that
-      # iterates over appIds, and single quotes can break out of jq's single-quoted
-      # string literals. Reject these at evaluation time so they never reach the
-      # generated shell script.
-      # TODO(gmodena, 2026-04): this list is expected to grow.
-      invalidChars = [ "\n" "\r" "\x00" "'" ];
-      hasInvalidChar = path: builtins.any (c: lib.strings.hasInfix c path) invalidChars;
-      invalidPaths = builtins.filter hasInvalidChar files;
-    in
+    # Paths flow through jq into a shell `cat "$OVERRIDE_FILE"` invocation.
+    # Newlines and null bytes corrupt the `while read` loop that
+    # iterates over appIds, and single quotes can break out of jq's single-quoted
+    # string literals. Reject these at evaluation time so they never reach the
+    # generated shell script.
+    # TODO(gmodena, 2026-04): this list is expected to grow.
+    invalidChars = ["\n" "\r" "\x00" "'"];
+    hasInvalidChar = path: builtins.any (c: lib.strings.hasInfix c path) invalidChars;
+    invalidPaths = builtins.filter hasInvalidChar files;
+  in
     if invalidPaths != []
-    then throw ''
-      services.flatpak.overrides.files: the following paths contain invalid characters: ${builtins.toJSON invalidPaths}
-    ''
+    then
+      throw ''
+        services.flatpak.overrides.files: the following paths contain invalid characters: ${builtins.toJSON invalidPaths}
+      ''
     else if duplicates != []
-    then throw ''
-      services.flatpak.overrides.files: duplicate override file basenames detected: ${builtins.concatStringsSep ", " duplicates}.
-      Flatpak uses the basename as the app ID key; each path must have a unique basename.
-      Conflicting paths: ${builtins.toJSON files}
-    ''
+    then
+      throw ''
+        services.flatpak.overrides.files: duplicate override file basenames detected: ${builtins.concatStringsSep ", " duplicates}.
+        Flatpak uses the basename as the app ID key; each path must have a unique basename.
+        Conflicting paths: ${builtins.toJSON files}
+      ''
     else
       builtins.listToAttrs (
         builtins.map (path: {
           name = builtins.baseNameOf path;
           value = path;
-        }) files
+        })
+        files
       );
 
-  flatpakOverridesCmd = installation: {}: ''
-    # Update overrides that are managed by this module (both old and new)
+  # For each appId with Nix-managed configuration, produces a store-path derivation
+  # containing the fully merged INI content.
+  # This is Lazily evaluated. builtins.readFile is only forced when
+  # writeMode == "replace".
+  replaceOverrideFiles = let
+    writeMode = cfg.overrides.writeMode or "merge";
+    allAppIds = lib.lists.unique (
+      builtins.attrNames (cfg.overrides.settings or {})
+      ++ builtins.attrNames overrideFiles
+    );
+    fileSettingsByApp =
+      builtins.mapAttrs
+      (_: path: ini.parseIniContent (builtins.readFile (builtins.toPath path)))
+      overrideFiles;
+    mergeForApp = appId:
+      pkgs.writeText appId (ini.toIniContent
+        (ini.mergeOverrideSettings (cfg.overrides.settings or {}) fileSettingsByApp appId));
+  in
+    if writeMode == "replace"
+    then
+      builtins.listToAttrs (map (appId: {
+          name = appId;
+          value = mergeForApp appId;
+        })
+        allAppIds)
+    else {};
+
+  flatpakOverridesMergeCmd = installation: ''
+    # Update overrides that are managed by this module.
+    # Merge precedence: overrides.settings > overrides._fileSettings > active (direct edits).
+    # When a setting or file is removed from the Nix config the active override file is left
+    # untouched, preserving any direct edits the user made outside of nix-flatpak.
     ${pkgs.coreutils}/bin/mkdir -p ${overridesDir}
     ${pkgs.jq}/bin/jq -r -n \
       --argjson old "$OLD_STATE" \
       --argjson new "$NEW_STATE" \
-      --argjson override_files '${builtins.toJSON overrideFiles}' \
-      '[((($new.overrides.settings // $new.overrides) + ($old.overrides.settings // $old.overrides) | keys[]),
-        ($override_files | keys[]),
-        ($old.overrides.files // [] | map(split("/") | last) | .[]))] | unique[]' \
+      '[ (($new.overrides.settings // $new.overrides) | keys[]),
+         (($new.overrides._fileSettings // {}) | keys[]),
+         (($old.overrides.settings // $old.overrides) | keys[]),
+         ($old.overrides.files // [] | map(split("/") | last) | .[]) ] | unique[]' \
       | while read -r APP_ID; do
         OVERRIDES_PATH=${overridesDir}/$APP_ID
 
-        # Get the corresponding file from overrideFiles list (if it exists)
-        OVERRIDE_FILE=$(${pkgs.jq}/bin/jq -r -n \
-          --arg app_id "$APP_ID" \
-          --argjson override_files '${builtins.toJSON  overrideFiles}' \
-          '$override_files[$app_id] // empty')
-
-        # Check if file was removed (was in old state, not in current config)
-        WAS_FILE_REMOVED=$(${pkgs.jq}/bin/jq -r -n \
-          --arg app_id "$APP_ID" \
-          --argjson old "$OLD_STATE" \
-          --argjson override_files '${builtins.toJSON overrideFiles}' \
-          '($old.overrides.files // [] | map(split("/") | last) | index($app_id) != null) and
-           ($override_files[$app_id] == null)')
-
-        # Check if app has any new configuration (settings or override file)
+        # Check if app has any new nix-managed configuration (settings or file-based settings)
         HAS_NEW_CONFIG=$(${pkgs.jq}/bin/jq -r -n \
           --arg app_id "$APP_ID" \
           --argjson new "$NEW_STATE" \
-          --argjson override_files '${builtins.toJSON overrideFiles}' \
           '(($new.overrides.settings[$app_id] // $new.overrides[$app_id]) != null) or
-           ($override_files[$app_id] != null)')
+           (($new.overrides._fileSettings[$app_id] // null) != null)')
 
-        # Skip orphaned apps when deleteOrphanedFiles=false
-        # (apps only from removed files with no new configuration)
-        if [[ "$WAS_FILE_REMOVED" == "true" && "$HAS_NEW_CONFIG" == "false" ]]; then
-          ${if (cfg.overrides.deleteOrphanedFiles or false) then ":" else "continue"}
-        fi
+        # Check if app was previously managed via overrides.files
+        WAS_FILE_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
+          --arg app_id "$APP_ID" \
+          --argjson old "$OLD_STATE" \
+          '$old.overrides.files // [] | map(split("/") | last) | index($app_id) != null')
 
-        # Read the base file from overrideFiles and convert to JSON (if file exists)
-        if [[ -n "$OVERRIDE_FILE" && -f "$OVERRIDE_FILE" ]]; then
-          BASE_OVERRIDES=$(${pkgs.coreutils}/bin/cat "$OVERRIDE_FILE" \
-            | ${pkgs.jc}/bin/jc --ini \
-            | ${pkgs.jq}/bin/jq 'map_values(map_values(split(";") | select(. != []) // ""))')
-          HAS_OVERRIDE_FILE=true
-        else
-          BASE_OVERRIDES={}
-          HAS_OVERRIDE_FILE=false
+        # No new config and never managed via files: leave the active override file as-is (preserves direct edits)
+        # If app was previously managed via files, fall through to the merge so stale _fileSettings keys are retracted.
+        if [[ "$HAS_NEW_CONFIG" == "false" && "$WAS_FILE_MANAGED" == "false" ]]; then
+          continue
         fi
 
         # Read existing active overrides if they exist
@@ -268,21 +295,20 @@ let
           ACTIVE={}
         fi
 
-        # Generate and save the updated overrides file
+        # Generate and save the updated overrides file.
+        # settings wins, then _fileSettings, then active (direct edits preserved for unmanaged keys).
+        # old_state is passed so overrides.jq can retract stale _fileSettings keys on file removal.
         ${pkgs.jq}/bin/jq -r -n \
           --arg app_id "$APP_ID" \
-          --argjson base_overrides "$BASE_OVERRIDES" \
           --argjson active "$ACTIVE" \
-          --argjson old_state "$OLD_STATE" \
           --argjson new_state "$NEW_STATE" \
-          --argjson has_override_file "$HAS_OVERRIDE_FILE" \
-          --argjson file_was_removed "$WAS_FILE_REMOVED" \
+          --argjson old_state "$OLD_STATE" \
           --from-file ${./state/overrides.jq} \
-          >$OVERRIDES_PATH
+          >"$OVERRIDES_PATH.tmp" && ${pkgs.coreutils}/bin/mv "$OVERRIDES_PATH.tmp" "$OVERRIDES_PATH"
       done
 
     # Delete override files that were previously managed by nix-flatpak but have since been removed from configuration.
-    ${lib.optionalString (cfg.overrides.deleteOrphanedFiles or false) ''
+    ${lib.optionalString (cfg.overrides.pruneUnmanagedOverrides or false) ''
       if [[ -d "${overridesDir}" ]]; then
         for OVERRIDE_FILE in "${overridesDir}"/*; do
           [[ -f "$OVERRIDE_FILE" ]] || continue
@@ -295,13 +321,12 @@ let
             '(($old.overrides.settings[$app_id] // $old.overrides[$app_id]) != null) or
              ($old.overrides.files // [] | map(split("/") | last) | index($app_id) != null)')
 
-          # Check if this app is managed in current config (settings or files)
+          # Check if this app is managed in current config (settings or _fileSettings)
           OVERRIDES_IS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
             --arg app_id "$APP_ID" \
             --argjson new "$NEW_STATE" \
-            --argjson override_files '${builtins.toJSON overrideFiles}' \
             '(($new.overrides.settings[$app_id] // $new.overrides[$app_id]) != null) or
-             ($override_files[$app_id] != null)')
+             (($new.overrides._fileSettings[$app_id] // null) != null)')
 
           # Only delete if it was ours and we've stopped managing it
           if [[ "$OVERRIDES_WAS_MANAGED" == "true" && "$OVERRIDES_IS_MANAGED" == "false" ]]; then
@@ -310,104 +335,179 @@ let
         done
       fi
     ''}
+  '';
+
+  # writeMode = "replace": copy pre-computed store derivations to overridesDir.
+  # Nix fully owns the file contents.
+  flatpakOverridesReplaceCmd = installation: ''
+    ${pkgs.coreutils}/bin/mkdir -p ${overridesDir}
+    ${builtins.concatStringsSep "\n" (
+      lib.mapAttrsToList (appId: drv: ''
+        ${pkgs.coreutils}/bin/cp --no-preserve=mode,ownership ${drv} ${overridesDir}/${appId}.tmp && ${pkgs.coreutils}/bin/mv ${overridesDir}/${appId}.tmp ${overridesDir}/${appId}
+      '')
+      replaceOverrideFiles
+    )}
+    # Delete override files that were previously managed by nix-flatpak but have since been removed from configuration.
+    ${lib.optionalString (cfg.overrides.pruneUnmanagedOverrides or false) ''
+      if [[ -d "${overridesDir}" ]]; then
+        for OVERRIDE_FILE in "${overridesDir}"/*; do
+          [[ -f "$OVERRIDE_FILE" ]] || continue
+          APP_ID=$(${pkgs.coreutils}/bin/basename "$OVERRIDE_FILE")
+
+          OVERRIDES_WAS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
+            --arg app_id "$APP_ID" \
+            --argjson old "$OLD_STATE" \
+            '(($old.overrides.settings[$app_id] // $old.overrides[$app_id]) != null) or
+             ($old.overrides.files // [] | map(split("/") | last) | index($app_id) != null)')
+
+          OVERRIDES_IS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
+            --arg app_id "$APP_ID" \
+            --argjson new "$NEW_STATE" \
+            '(($new.overrides.settings[$app_id] // $new.overrides[$app_id]) != null) or
+             (($new.overrides._fileSettings[$app_id] // null) != null)')
+
+          if [[ "$OVERRIDES_WAS_MANAGED" == "true" && "$OVERRIDES_IS_MANAGED" == "false" ]]; then
+            ${pkgs.coreutils}/bin/rm -f "$OVERRIDE_FILE"
+          fi
+        done
+      fi
+    ''}
+  '';
+
+  flatpakOverridesCmd = installation: {}:
+    if (cfg.overrides.writeMode or "merge") == "replace"
+    then flatpakOverridesReplaceCmd installation
+    else flatpakOverridesMergeCmd installation;
+
+  flatpakInstallCmd = installation: update: {
+    appId,
+    origin ? "flathub",
+    commit ? null,
+    flatpakref ? null,
+    bundle ? null,
+    sha256 ? null,
+    ...
+  }: let
+    isBundle = bundle != null;
+
+    cmdBuilder = installation: action: args: "${pkgs.flatpak}/bin/flatpak --${installation} --noninteractive ${action} ${args}";
+
+    installCmdBuilder = installation: update: appId: flatpakref: origin: let
+      updateFlag =
+        if update
+        then "--or-update"
+        else "";
+      # Different format require to specify different sourceArgs
+      sourceArgs =
+        if utils.isFlatpakref {flatpakref = flatpakref;}
+        then installOrUpdateFromFlatpakref flatpakref installation
+        else "${origin} ${appId}";
+    in
+      cmdBuilder installation "install" "${updateFlag} ${sourceArgs}";
+
+    resolvedAppId =
+      if flatpakref != null
+      then flatpakrefCache.${(utils.sanitizeUrl flatpakref)}.Name
+      else appId;
+
+    # flatpak install ...
+    installCmd =
+      if isBundle
+      then null
+      else installCmdBuilder installation update appId flatpakref origin;
+    # Bundle specific code paths
+    installBundleCmd =
+      if isBundle
+      then cmdBuilder installation "install" "--bundle ${bundle}"
+      else null;
+
+    # flatpak update ...
+    updatePinnedCmd =
+      if commit != null
+      then cmdBuilder installation "update" "--commit=\"${commit}\" ${resolvedAppId}"
+      else "";
+
+    installAndUpdatePinnedCmd = ''
+      ${
+        if installCmd != null
+        then installCmd
+        else ""
+      }
+      ${
+        if updatePinnedCmd != null
+        then updatePinnedCmd
+        else ""
+      }
     '';
 
-  flatpakInstallCmd = installation: update: { appId, origin ? "flathub", commit ? null, flatpakref ? null, bundle ? null, sha256 ? null, ... }:
-      let
-        isBundle = bundle != null;
+    # Check if we need to execute flatpak install .... Which is when the state has changed:
+    # 1. the script needs to run with --or-update (update.onActivation and/or update.auto are enabled).
+    # 2. the application is not present in OLD_STATE and should be installed.
+    # 3. the application is present in OLD_STATE, but is now pinned (explicitly)
+    # at a different hash than the currently installed one.
+    determineFlatpakStateChange = let
+      safeCommit =
+        if commit == null
+        then ""
+        else commit;
+    in ''
+      if ${
+        if isBundle
+        then "true"
+        else "false"
+      }; then
+          # Check if sha256 changed between OLD_STATE and NEW_STATE
+          changedSha256="$(${pkgs.jq}/bin/jq -ns \
+            --argjson oldState "$OLD_STATE" \
+            --argjson newState "$NEW_STATE" \
+            --arg appId "${resolvedAppId}" \
+            -f ${./state/compare_sha.jq})"
 
-        cmdBuilder = installation: action: args:
-          "${pkgs.flatpak}/bin/flatpak --${installation} --noninteractive ${action} ${args}";
-
-        installCmdBuilder = installation: update: appId: flatpakref: origin:
-          let
- 
-            updateFlag = if update then "--or-update" else "";
-            # Different format require to specify different sourceArgs
-            sourceArgs =
-              if utils.isFlatpakref { flatpakref = flatpakref; }
-              then installOrUpdateFromFlatpakref flatpakref installation
-              else "${origin} ${appId}";
-          in
-            cmdBuilder installation "install" "${updateFlag} ${sourceArgs}";
-
-
-        resolvedAppId =
-          if flatpakref != null
-          then flatpakrefCache.${(utils.sanitizeUrl flatpakref)}.Name
-          else appId;
-
-        # flatpak install ...
-        installCmd = if isBundle then null else installCmdBuilder installation update appId flatpakref origin;
-        # Bundle specific code paths
-        installBundleCmd = if isBundle then cmdBuilder installation "install" "--bundle ${bundle}" else null;
-
-        # flatpak update ...
-        updatePinnedCmd =
-          if commit != null
-          then cmdBuilder installation "update" "--commit=\"${commit}\" ${resolvedAppId}"
-          else "";
-
-        installAndUpdatePinnedCmd = ''
-          ${if installCmd != null then installCmd else ""}
-          ${if updatePinnedCmd != null then updatePinnedCmd else ""}
-        '';
-
-        # Check if we need to execute flatpak install .... Which is when the state has changed:
-        # 1. the script needs to run with --or-update (update.onActivation and/or update.auto are enabled).
-        # 2. the application is not present in OLD_STATE and should be installed.
-        # 3. the application is present in OLD_STATE, but is now pinned (explicitly)
-        # at a different hash than the currently installed one.
-        determineFlatpakStateChange =
-          let
-            safeCommit = if commit == null then "" else commit;
-          in
-          ''
-            if ${if isBundle then "true" else "false"}; then
-                # Check if sha256 changed between OLD_STATE and NEW_STATE
-                changedSha256="$(${pkgs.jq}/bin/jq -ns \
-                  --argjson oldState "$OLD_STATE" \
-                  --argjson newState "$NEW_STATE" \
-                  --arg appId "${resolvedAppId}" \
-                  -f ${./state/compare_sha.jq})"
-
-                if [[ -n "$changedSha256" ]]; then
-                  if ${pkgs.flatpak}/bin/flatpak --${installation} info "${resolvedAppId}" &>/dev/null; then
-                    ${pkgs.flatpak}/bin/flatpak --${installation} uninstall -y "${resolvedAppId}"
-                    : # No operation if no install command needs to run.
-                  fi
-                  ${if isBundle then installBundleCmd else ""}
-                  : # No operation if no install command needs to run.
-                fi
-            else
-              # Check if app exists in old state, handling both formats
-              if $( ${pkgs.jq}/bin/jq -r -n --argjson old "$OLD_STATE" --arg appId "${resolvedAppId}" --from-file ${./state/app_exists.jq} | ${pkgs.gnugrep}/bin/grep -q true ); then
-                # App exists in old state, check if commit changed
-                if [[ -n "${safeCommit}" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --${installation} info "${resolvedAppId}" --show-commit 2>/dev/null )" != "${safeCommit}" ]]; then
-                  ${updatePinnedCmd}
-                  : # No operation if no install command needs to run.
-                elif ${if update then "true" else "false"}; then
-                  ${installAndUpdatePinnedCmd}
-                  : # No operation if no install command needs to run.
-                fi
-              else
-                ${installAndUpdatePinnedCmd}
-                : # No operation if no install command needs to run.
-              fi
+          if [[ -n "$changedSha256" ]]; then
+            if ${pkgs.flatpak}/bin/flatpak --${installation} info "${resolvedAppId}" &>/dev/null; then
+              ${pkgs.flatpak}/bin/flatpak --${installation} uninstall -y "${resolvedAppId}"
+              : # No operation if no install command needs to run.
             fi
-          '';
-      in
-      determineFlatpakStateChange;
-
+            ${
+        if isBundle
+        then installBundleCmd
+        else ""
+      }
+            : # No operation if no install command needs to run.
+          fi
+      else
+        # Check if app exists in old state, handling both formats
+        if $( ${pkgs.jq}/bin/jq -r -n --argjson old "$OLD_STATE" --arg appId "${resolvedAppId}" --from-file ${./state/app_exists.jq} | ${pkgs.gnugrep}/bin/grep -q true ); then
+          # App exists in old state, check if commit changed
+          if [[ -n "${safeCommit}" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --${installation} info "${resolvedAppId}" --show-commit 2>/dev/null )" != "${safeCommit}" ]]; then
+            ${updatePinnedCmd}
+            : # No operation if no install command needs to run.
+          elif ${
+        if update
+        then "true"
+        else "false"
+      }; then
+            ${installAndUpdatePinnedCmd}
+            : # No operation if no install command needs to run.
+          fi
+        else
+          ${installAndUpdatePinnedCmd}
+          : # No operation if no install command needs to run.
+        fi
+      fi
+    '';
+  in
+    determineFlatpakStateChange;
 
   flatpakInstall = installation: update: packages: map (flatpakInstallCmd installation update) packages;
-
 
   flatpakDeleteRemotesCmd = remotes.flatpakDeleteRemotesCmd;
 
   updateTrigger =
-    if executionContext == "service-start" then cfg.update.onActivation
-    else if executionContext == "timer" then cfg.update.auto.enable
+    if executionContext == "service-start"
+    then cfg.update.onActivation
+    else if executionContext == "timer"
+    then cfg.update.auto.enable
     else throw "flatpak-managed-install: invalid execution context `${executionContext}`" false;
 
   # Initializes state variables for managing Flatpak packages and remotes.
@@ -430,7 +530,7 @@ let
 
   # Generates a command to install Flatpak packages defined in `cfg.packages`.
   # Combines installation commands using `flatpakInstall` for each package.
-  # 
+  #
   # Inputs:
   # - installation: Installation context for Flatpak.
   # - updateTrigger: Triggers updates if enabled.
@@ -439,15 +539,15 @@ let
 
   # Generates a command to uninstall Flatpak packages.
   # Uses `flatpakUninstallCmd` to produce the necessary command.
-  # 
+  #
   # Inputs:
   # - installation: Installation context for Flatpak.
-  mkUninstallCmd = flatpakUninstallCmd installation { };
+  mkUninstallCmd = flatpakUninstallCmd installation {};
 
   # Creates a command to manage unmanaged Flatpak states based on configuration.
-  # Uses `handleUnmanagedStateCmd` with the current installation context and 
+  # Uses `handleUnmanagedStateCmd` with the current installation context and
   # the `cfg.uninstallUnmanaged` option.
-  # 
+  #
   # Inputs:
   # - installation: Installation context for Flatpak.
   # - cfg.uninstallUnmanaged: Boolean indicating whether to handle unmanaged packages.
@@ -455,22 +555,22 @@ let
 
   # Produces a command to delete Flatpak remotes if `cfg.uninstallUnmanaged` is enabled.
   # Uses `flatpakDeleteRemotesCmd` to build the command.
-  # 
+  #
   # Inputs:
   # - installation: Installation context for Flatpak.
   # - cfg.uninstallUnmanaged: Boolean to control removal of unmanaged remotes.
-  mkDeleteRemotesCmd = flatpakDeleteRemotesCmd installation cfg.uninstallUnmanaged { };
+  mkDeleteRemotesCmd = flatpakDeleteRemotesCmd installation cfg.uninstallUnmanaged {};
 
   # Generates a command to set Flatpak overrides based on the current installation context.
   # Uses `flatpakOverridesCmd` to build the command.
-  # 
+  #
   # Inputs:
   # - installation: Installation context for Flatpak.
-  mkOverridesCmd = flatpakOverridesCmd installation { };
+  mkOverridesCmd = flatpakOverridesCmd installation {};
 
   # Generates a command to uninstall unused Flatpak packages if `cfg.uninstallUnused` is enabled.
   # Otherwise, outputs a comment indicating the feature is not enabled.
-  # 
+  #
   # Inputs:
   # - installation: Installation context for Flatpak.
   # - cfg.uninstallUnused: Boolean indicating whether to uninstall unused packages.
@@ -481,28 +581,26 @@ let
 
   # Links the current state file (`stateFile`) to the state path (`statePath`).
   # This ensures that the current state is saved persistently.
-  # 
+  #
   # Inputs:
   # - stateFile: Path to the current state file.
   # - statePath: Path to save the state file.
   # - pkgs.coreutils: Used for accessing the `ln` utility.
-  mkSaveStateCmd = '' 
+  mkSaveStateCmd = ''
     ${pkgs.coreutils}/bin/ln -sf ${stateFile} ${statePath}
   '';
 
   # Generates a command to add Flatpak remotes based on the provided configuration and installation context.
   # Delegates to `remotes.mkFlatpakAddRemotesCmd` to construct the necessary commands.
-  # 
+  #
   # Inputs:
   # - installation: Installation context for Flatpak.
   # - cfg.remotes: Configuration specifying the remotes to be added.
   # - remotes: Module providing the `mkFlatpakAddRemotesCmd` function.
-  # 
+  #
   # Output:
   # - Command to add the specified Flatpak remotes.
   mkAddRemotesCmd = remotes.mkFlatpakAddRemotesCmd installation cfg.remotes;
-
-in
-{
-  inherit mkLoadStateCmd mkInstallCmd mkUninstallCmd mkHandleUnmanagedStateCmd mkAddRemotesCmd mkDeleteRemotesCmd mkOverridesCmd mkUninstallUnusedCmd mkSaveStateCmd;
+in {
+  inherit mkLoadStateCmd mkInstallCmd mkUninstallCmd mkHandleUnmanagedStateCmd mkAddRemotesCmd mkDeleteRemotesCmd mkOverridesCmd mkUninstallUnusedCmd mkSaveStateCmd replaceOverrideFiles;
 }

--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -175,7 +175,9 @@ let
       --argjson old "$OLD_STATE" \
       --argjson new "$NEW_STATE" \
       --argjson override_files '${builtins.toJSON overrideFiles}' \
-      '[(((try $new.overrides.settings catch $new.overrides) + (try $old.overrides.settings catch $old.overrides) | keys[]), ($override_files | keys[]))] | unique[]' \
+      '[(((try $new.overrides.settings catch $new.overrides) + (try $old.overrides.settings catch $old.overrides) | keys[]),
+        ($override_files | keys[]),
+        ($old.overrides.files // [] | map(split("/") | last) | .[]))] | unique[]' \
       | while read -r APP_ID; do
         OVERRIDES_PATH=${overridesDir}/$APP_ID
 
@@ -185,15 +187,39 @@ let
           --argjson override_files '${builtins.toJSON  overrideFiles}' \
           '$override_files[$app_id] // empty')
 
+        # Check if file was removed (was in old state, not in current config)
+        WAS_FILE_REMOVED=$(${pkgs.jq}/bin/jq -r -n \
+          --arg app_id "$APP_ID" \
+          --argjson old "$OLD_STATE" \
+          --argjson override_files '${builtins.toJSON overrideFiles}' \
+          '($old.overrides.files // [] | map(split("/") | last) | index($app_id) != null) and
+           ($override_files[$app_id] == null)')
+
+        # Check if app has any new configuration (settings or override file)
+        HAS_NEW_CONFIG=$(${pkgs.jq}/bin/jq -r -n \
+          --arg app_id "$APP_ID" \
+          --argjson new "$NEW_STATE" \
+          --argjson override_files '${builtins.toJSON overrideFiles}' \
+          '((try $new.overrides.settings[$app_id] catch $new.overrides[$app_id]) != null) or
+           ($override_files[$app_id] != null)')
+
+        # Skip orphaned apps when deleteOrphanedFiles=false
+        # (apps only from removed files with no new configuration)
+        if [[ "$WAS_FILE_REMOVED" == "true" && "$HAS_NEW_CONFIG" == "false" ]]; then
+          ${if cfg.overrides.deleteOrphanedFiles then ":" else "continue"}
+        fi
+
         # Read the base file from overrideFiles and convert to JSON (if file exists)
         if [[ -n "$OVERRIDE_FILE" && -f "$OVERRIDE_FILE" ]]; then
           BASE_OVERRIDES=$(${pkgs.coreutils}/bin/cat "$OVERRIDE_FILE" \
             | ${pkgs.jc}/bin/jc --ini \
             | ${pkgs.jq}/bin/jq 'map_values(map_values(split(";") | select(. != []) // ""))')
+          HAS_OVERRIDE_FILE=true
         else
           BASE_OVERRIDES={}
+          HAS_OVERRIDE_FILE=false
         fi
-        
+
         # Read existing active overrides if they exist
         if [[ -f $OVERRIDES_PATH ]]; then
           ACTIVE=$(${pkgs.coreutils}/bin/cat $OVERRIDES_PATH \
@@ -202,7 +228,7 @@ let
         else
           ACTIVE={}
         fi
-        
+
         # Generate and save the updated overrides file
         ${pkgs.jq}/bin/jq -r -n \
           --arg app_id "$APP_ID" \
@@ -210,9 +236,34 @@ let
           --argjson active "$ACTIVE" \
           --argjson old_state "$OLD_STATE" \
           --argjson new_state "$NEW_STATE" \
+          --argjson has_override_file "$HAS_OVERRIDE_FILE" \
+          --argjson file_was_removed "$WAS_FILE_REMOVED" \
           --from-file ${./state/overrides.jq} \
           >$OVERRIDES_PATH
       done
+
+    # Delete orphaned override files when deleteOrphanedFiles mode is enabled
+    # Scan actual disk to catch files that were orphaned before deleteOrphanedFiles was enabled
+    ${lib.optionalString cfg.overrides.deleteOrphanedFiles ''
+      if [[ -d "${overridesDir}" ]]; then
+        for OVERRIDE_FILE in "${overridesDir}"/*; do
+          [[ -f "$OVERRIDE_FILE" ]] || continue
+          APP_ID=$(${pkgs.coreutils}/bin/basename "$OVERRIDE_FILE")
+
+          # Check if this app is managed in current config (settings or files)
+          IS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
+            --arg app_id "$APP_ID" \
+            --argjson new "$NEW_STATE" \
+            --argjson override_files '${builtins.toJSON overrideFiles}' \
+            '((try $new.overrides.settings[$app_id] catch $new.overrides[$app_id]) != null) or
+             ($override_files[$app_id] != null)')
+
+          if [[ "$IS_MANAGED" == "false" ]]; then
+            ${pkgs.coreutils}/bin/rm -f "$OVERRIDE_FILE"
+          fi
+        done
+      fi
+    ''}
     '';
 
   flatpakInstallCmd = installation: update: { appId, origin ? "flathub", commit ? null, flatpakref ? null, bundle ? null, sha256 ? null, ... }:

--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -260,9 +260,9 @@
     ${pkgs.jq}/bin/jq -r -n \
       --argjson old "$OLD_STATE" \
       --argjson new "$NEW_STATE" \
-      '[ (($new.overrides.settings // $new.overrides) | keys[]),
+      '[ (if ($new.version // 1) >= 2 then ($new.overrides.settings // {}) else ($new.overrides // {}) end | keys[]),
          (($new.overrides._fileSettings // {}) | keys[]),
-         (($old.overrides.settings // $old.overrides) | keys[]),
+         (if ($old.version // 1) >= 2 then ($old.overrides.settings // {}) else ($old.overrides // {}) end | keys[]),
          ($old.overrides.files // [] | map(split("/") | last) | .[]) ] | unique[]' \
       | while read -r APP_ID; do
         OVERRIDES_PATH=${overridesDir}/$APP_ID

--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -12,6 +12,9 @@ let
     (builtins.filter (package: utils.isFlatpakref package) cfg.packages);
 
   # We use an incremental versioning scheme for the state file. For internal use only.
+  # none. legacy state management
+  # 1. Initial state object format. Store package and remotes attrsets instead of just keys.
+  # 2. Added support of `overrides.settings` and `overrides.files` attrs.
   formatVersion = 2;
 
   # Put the state file in the `gcroots` folder of the respective installation,

--- a/modules/flatpak/state/overrides.jq
+++ b/modules/flatpak/state/overrides.jq
@@ -39,8 +39,8 @@ def values($value):
   end;
 
 # Extract state aliases for the current app
-($old_state.overrides[$app_id] // {}) as $old
-| ($new_state.overrides[$app_id] // {}) as $new
+(try $old_state.overrides.settings[$app_id] catch $old_state.overrides[$app_id]) as $old
+| (try $new_state.overrides.settings[$app_id] catch $new_state.overrides) as $new
 # Process all sections that exist in base, active, or new state
 | $base_overrides + $active + $new
 | keys

--- a/modules/flatpak/state/overrides.jq
+++ b/modules/flatpak/state/overrides.jq
@@ -1,42 +1,90 @@
-# Convert entry value into array
-def values ($value): if ($value | type) == "string" then [$value] else ($value // []) end;
+# Flatpak Overrides Merge Script
+#
+# This script merges Flatpak override configurations from multiple sources:
+# - base_overrides: Base configuration from override files
+# - active: Currently active overrides (existing state)
+# - old_state: Previous declarative state
+# - new_state: New declarative state
+#
+# Merge Logic:
+# The script applies changes on top of base configuration while preserving
+# manual modifications that weren't part of the previous declarative state.
+#
+# For each entry, the merge formula is:
+#   base + (active - old) + new
+#
+# Where:
+# - base: Always preserved from override files
+# - active - old: Manual changes (active values not from old state)
+# - new: New declarative state values
+#
+# Special handling:
+# - If new value is a string: Completely replaces the merged array
+# - If new value is an array: Merges with base and filtered active values
+# - Arrays are deduplicated and sorted alphabetically
+#
+# Input parameters:
+# - $app_id: Application identifier
+# - $base_overrides: Base configuration from files
+# - $active: Currently active overrides
+# - $old_state: Previous state for this app
+# - $new_state: New state for this app
 
-# State aliases
+# Convert entry value into array for consistent processing
+def values($value):
+  if ($value | type) == "string" then
+    $value | split(";") | map(select(. != "" and . != null))
+  else
+    ($value // [])
+  end;
+
+# Extract state aliases for the current app
 ($old_state.overrides[$app_id] // {}) as $old
 | ($new_state.overrides[$app_id] // {}) as $new
+# Process all sections that exist in base, active, or new state
+| $base_overrides + $active + $new
+| keys
+| map(
+    . as $section
+    | {
+        "section_key": $section,
+        "section_value": (
+          # Process all entries that exist in base, active, or new state for this section
+          ($base_overrides[$section] // {}) + ($active[$section] // {}) + ($new[$section] // {})
+          | keys
+          | map(
+              . as $entry
+              | {
+                  "entry_key": $entry,
+                  "entry_value": (
+                    # Extract value aliases for current entry
+                    $base_overrides[$section][$entry] as $base_value
+                    | $active[$section][$entry] as $active_value
+                    | $new[$section][$entry] as $new_value
+                    | $old[$section][$entry] as $old_value
+                    # Apply merge logic
+                    | if ($new_value | type) == "string" then
+                        # String values completely override arrays
+                        $new_value
+                      else
+                        # Array merge: base + (active - old) + new
+                        values($base_value) + (values($active_value) - values($old_value)) + values($new_value)
+                        # Remove empty arrays and deduplicate/sort values
+                        | select(. != [])
+                        | map(select(. != ""))
+                        # Remove duplicates and empy values, while preserving the original value order in output configs
+                        | . as $arr | reduce .[] as $item ([]; if . | contains([$item]) then . else . + [$item] end)
+                        # Convert array back to Flatpak string format
+                        | join(";")
+                      end
+                  )
+                }
+            )
+          # Remove entries with empty values
+          | select(. != [])
+        )
+      }
+  )[]
 
-# Map sections that exist in either active or new state (ignore old)
-| $active + $new | keys | map (
-. as $section | {"section_key": $section, "section_value": (
-
-# Map entries that exist in either active or new state (ignore old)
-($active[$section] // {}) + ($new[$section] // {}) | keys | map (
-. as $entry | { "entry_key": $entry, "entry_value": (
-
-# Entry value aliases
-$active[$section][$entry] as $active_value
-| $new[$section][$entry]    as $new_value
-| $old[$section][$entry]    as $old_value
-
-# Use new value if it is a string
-| if ($new_value | type) == "string" then $new_value
-else
-# Otherwise remove old values from the active ones, and add the new ones
-values($active_value) - values($old_value) + values($new_value)
-
-# Remove empty arrays and duplicate values
-| select(. != []) | unique
-
-# Convert array into Flatpak string array format
-| join(";")
-end
-)}
-)
-
-# Remove empty arrays
-| select(. != [])
-)}
-)[]
-
-# Generate the final overrides file
+# Generate the final INI-format overrides file
 | "[\(.section_key)]", (.section_value[] | "\(.entry_key)=\(.entry_value)"), ""

--- a/modules/flatpak/state/overrides.jq
+++ b/modules/flatpak/state/overrides.jq
@@ -5,12 +5,19 @@
 # - active: Currently active overrides (existing state)
 # - old_state: Previous declarative state
 # - new_state: New declarative state
+# - has_override_file: Boolean flag indicating if an override file is being used
+# - file_was_removed: Boolean flag indicating if an override file was removed
 #
 # Merge Logic:
 # The script applies changes on top of base configuration while preserving
 # manual modifications that weren't part of the previous declarative state.
 #
 # For each entry, the merge formula is:
+# When `has_override_file` is true:
+#   base + new
+# When `file_was_removed` is true:
+#   base + new (authoritative merge, don't preserve "manual" changes from removed file)
+# When `has_override_file` is false and `file_was_removed` is false:
 #   base + (active - old) + new
 #
 # Where:
@@ -29,6 +36,8 @@
 # - $active: Currently active overrides
 # - $old_state: Previous state for this app
 # - $new_state: New state for this app
+# - $has_override_file: Boolean flag indicating if a file is present
+# - $file_was_removed: Boolean flag indicating if a file was removed from config
 
 # Convert entry value into array for consistent processing
 def values($value):
@@ -39,8 +48,9 @@ def values($value):
   end;
 
 # Extract state aliases for the current app
-(try $old_state.overrides.settings[$app_id] catch $old_state.overrides[$app_id]) as $old
-| (try $new_state.overrides.settings[$app_id] catch $new_state.overrides) as $new
+# Support both new format (overrides.settings) and legacy format (overrides directly)
+($old_state.overrides.settings[$app_id] // $old_state.overrides[$app_id]) as $old
+| ($new_state.overrides.settings[$app_id] // $new_state.overrides[$app_id]) as $new
 # Process all sections that exist in base, active, or new state
 | $base_overrides + $active + $new
 | keys
@@ -67,8 +77,15 @@ def values($value):
                         # String values completely override arrays
                         $new_value
                       else
-                        # Array merge: base + (active - old) + new
-                        values($base_value) + (values($active_value) - values($old_value)) + values($new_value)
+                        # Array merge: authoritative if file exists or was removed, else preserve manual
+                        (if $has_override_file then
+                          values($base_value) + values($new_value)
+                        elif $file_was_removed then
+                          # File was removed - use authoritative merge, don't preserve "manual" changes
+                          values($base_value) + values($new_value)
+                        else
+                          values($base_value) + (values($active_value) - values($old_value)) + values($new_value)
+                        end)
                         # Remove empty arrays and deduplicate/sort values
                         | select(. != [])
                         | map(select(. != ""))

--- a/modules/flatpak/state/overrides.jq
+++ b/modules/flatpak/state/overrides.jq
@@ -1,107 +1,68 @@
 # Flatpak Overrides Merge Script
 #
-# This script merges Flatpak override configurations from multiple sources:
-# - base_overrides: Base configuration from override files
-# - active: Currently active overrides (existing state)
-# - old_state: Previous declarative state
-# - new_state: New declarative state
-# - has_override_file: Boolean flag indicating if an override file is being used
-# - file_was_removed: Boolean flag indicating if an override file was removed
+# Merge precedence (highest to lowest):
+# 1. overrides.settings     - declarative Nix settings
+# 2. overrides._fileSettings - settings from override files (parsed at evaluation time)
+# 3. active overrides        - existing override file in the install dir (direct edits)
 #
-# Merge Logic:
-# The script applies changes on top of base configuration while preserving
-# manual modifications that weren't part of the previous declarative state.
-#
-# For each entry, the merge formula is:
-# When `has_override_file` is true:
-#   base + new
-# When `file_was_removed` is true:
-#   base + new (authoritative merge, don't preserve "manual" changes from removed file)
-# When `has_override_file` is false and `file_was_removed` is false:
-#   base + (active - old) + new
-#
-# Where:
-# - base: Always preserved from override files
-# - active - old: Manual changes (active values not from old state)
-# - new: New declarative state values
-#
-# Special handling:
-# - If new value is a string: Completely replaces the merged array
-# - If new value is an array: Merges with base and filtered active values
-# - Arrays are deduplicated and sorted alphabetically
+# For each key in each section, the highest-priority source that defines the key wins.
+# When a setting or file is removed from the Nix config, the corresponding entry in the
+# active override file is preserved only if it was a direct user edit. Keys that
+# were previously written by nix-flatpak via overrides.files (_fileSettings) are retracted
+# when the file is removed from the config.
 #
 # Input parameters:
-# - $app_id: Application identifier
-# - $base_overrides: Base configuration from files
-# - $active: Currently active overrides
-# - $old_state: Previous state for this app
-# - $new_state: New state for this app
-# - $has_override_file: Boolean flag indicating if a file is present
-# - $file_was_removed: Boolean flag indicating if a file was removed from config
+# - $app_id:    Application identifier
+# - $active:    Currently active overrides from the override install dir
+# - $new_state: New declarative state (contains .overrides.settings and .overrides._fileSettings)
+# - $old_state: Previous declarative state (used to detect stale _fileSettings keys)
 
-# Convert entry value into array for consistent processing
-def values($value):
-  if ($value | type) == "string" then
-    $value | split(";") | map(select(. != "" and . != null))
+# Normalize a value to a semicolon-joined string for INI output.
+def normalize:
+  if type == "array" then
+    map(select(. != "" and . != null)) | join(";")
   else
-    ($value // [])
+    (. // "")
   end;
 
-# Extract state aliases for the current app
-# Support both new format (overrides.settings) and legacy format (overrides directly)
-($old_state.overrides.settings[$app_id] // $old_state.overrides[$app_id]) as $old
-| ($new_state.overrides.settings[$app_id] // $new_state.overrides[$app_id]) as $new
-# Process all sections that exist in base, active, or new state
-| $base_overrides + $active + $new
-| keys
+# Support both v2 format (overrides.settings) and legacy v1 format (overrides directly on app keys)
+($new_state.overrides.settings[$app_id] // $new_state.overrides[$app_id] // {}) as $settings
+| ($new_state.overrides._fileSettings[$app_id] // {}) as $file_settings
+| ($old_state.overrides._fileSettings[$app_id] // {}) as $old_file_settings
+
+# Collect all sections from all three sources
+| ([ ($settings | keys[]), ($file_settings | keys[]), ($active | keys[]) ] | unique)
 | map(
     . as $section
     | {
         "section_key": $section,
         "section_value": (
-          # Process all entries that exist in base, active, or new state for this section
-          ($base_overrides[$section] // {}) + ($active[$section] // {}) + ($new[$section] // {})
-          | keys
+          [ (($settings[$section] // {}) | keys[]),
+            (($file_settings[$section] // {}) | keys[]),
+            (($active[$section] // {}) | keys[]) ]
+          | unique
           | map(
               . as $entry
-              | {
-                  "entry_key": $entry,
-                  "entry_value": (
-                    # Extract value aliases for current entry
-                    $base_overrides[$section][$entry] as $base_value
-                    | $active[$section][$entry] as $active_value
-                    | $new[$section][$entry] as $new_value
-                    | $old[$section][$entry] as $old_value
-                    # Apply merge logic
-                    | if ($new_value | type) == "string" then
-                        # String values completely override arrays
-                        $new_value
-                      else
-                        # Array merge: authoritative if file exists or was removed, else preserve manual
-                        (if $has_override_file then
-                          values($base_value) + values($new_value)
-                        elif $file_was_removed then
-                          # File was removed - use authoritative merge, don't preserve "manual" changes
-                          values($base_value) + values($new_value)
-                        else
-                          values($base_value) + (values($active_value) - values($old_value)) + values($new_value)
-                        end)
-                        # Remove empty arrays and deduplicate/sort values
-                        | select(. != [])
-                        | map(select(. != ""))
-                        # Remove duplicates and empy values, while preserving the original value order in output configs
-                        | . as $arr | reduce .[] as $item ([]; if . | contains([$item]) then . else . + [$item] end)
-                        # Convert array back to Flatpak string format
-                        | join(";")
-                      end
-                  )
-                }
+              | ($settings[$section][$entry]) as $s
+              | ($file_settings[$section][$entry]) as $f
+              | ($active[$section][$entry]) as $a
+              # Strict precedence: settings wins, then file_settings, then active.
+              # Active keys that were previously written by _fileSettings (old_file_settings)
+              # but are no longer claimed by any Nix config are retracted, not preserved.
+              # Active keys from direct edits  are preserved.
+              | if $s != null then { "entry_key": $entry, "entry_value": ($s | normalize) }
+                elif $f != null then { "entry_key": $entry, "entry_value": ($f | normalize) }
+                elif $a != null and ($old_file_settings[$section][$entry] == null) then
+                  { "entry_key": $entry, "entry_value": ($a | normalize) }
+                else empty
+                end
             )
-          # Remove entries with empty values
-          | select(. != [])
+          | map(select(.entry_value != ""))
         )
       }
-  )[]
+    | select(.section_value | length > 0)
+  )
+| .[]
 
-# Generate the final INI-format overrides file
+# Generate the final INI overrides file
 | "[\(.section_key)]", (.section_value[] | "\(.entry_key)=\(.entry_value)"), ""

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -60,9 +60,9 @@ let
       bundle = mkOption {
         type = types.nullOr types.str;
         description = ''
-            Path to a local Flatpak bundle to install. The file name should follow Flatpak's conventions:
-            https://docs.flatpak.org/en/latest/conventions.html
-          '';
+          Path to a local Flatpak bundle to install. The file name should follow Flatpak's conventions:
+          https://docs.flatpak.org/en/latest/conventions.html
+        '';
         default = null;
       };
     };
@@ -167,6 +167,42 @@ let
     };
   };
 
+  overridesOptions = _: {
+    options = {
+      settings = mkOption {
+        type = with types; attrsOf (attrsOf (attrsOf (either str (listOf str))));
+        default = { };
+        description = ''
+          Applies the provided attribute set into a Flatpak overrides file with the
+          same structure, keeping externally applied changes.
+        '';
+        example = literalExpression ''
+          {
+            # Array entries will be merged with externally applied values
+            "com.visualstudio.code".Context.sockets = ["wayland" "!x11" "!fallback-x11"];
+            # String entries will override externally applied values
+            global.Environment.LC_ALL = "C.UTF-8";
+          };
+        '';
+      };
+
+      files = mkOption {
+        type = with types; listOf str;
+        default = [ ];
+        description = ''
+          A list of paths to Flatpak overrides files.
+          The files will be merged with the overrides attribute set.
+          The files are expected to be in the same format as the overrides attribute set.
+        '';
+        example = literalExpression ''
+          [
+            "/path/to/overrides.d/com.visualstudio.code"
+            "/path/to/overrides.d/org.gnome.Terminal"
+          ];
+        '';
+      };
+    };
+  };
 in
 {
   packages = mkOption {
@@ -199,7 +235,8 @@ in
   };
 
   overrides = mkOption {
-    type = with types; attrsOf (attrsOf (attrsOf (either str (listOf str))));
+    #type = with types; coercedTo attrs (attrs: { inherit attrs; }) (submodule overridesOptions);
+    # type = with types; attrsOf (coercedTo attrs (attrs: { inherit attrs; }) (submodule overridesOptions));
     default = { };
     description = ''
       Applies the provided attribute set into a Flatpak overrides file with the
@@ -212,22 +249,6 @@ in
         # String entries will override externally applied values
         global.Environment.LC_ALL = "C.UTF-8";
       };
-    '';
-  };
-
-  overridesFiles = mkOption {
-    type = with types; listOf str;
-    default = [ ];
-    description = ''
-      A list of paths to Flatpak overrides files.
-      The files will be merged with the overrides attribute set.
-      The files are expected to be in the same format as the overrides attribute set.
-    '';
-    example = literalExpression ''
-      [
-        "./overrides.d/com.visualstudio.code"
-        "./overrides.d/org.gnome.Terminal"
-      ];
     '';
   };
 

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -215,6 +215,22 @@ in
     '';
   };
 
+  overridesFiles = mkOption {
+    type = with types; listOf str;
+    default = [ ];
+    description = ''
+      A list of paths to Flatpak overrides files.
+      The files will be merged with the overrides attribute set.
+      The files are expected to be in the same format as the overrides attribute set.
+    '';
+    example = literalExpression ''
+      [
+        "./overrides.d/com.visualstudio.code"
+        "./overrides.d/org.gnome.Terminal"
+      ];
+    '';
+  };
+
   update = mkOption {
     type = with types; submodule updateOptions;
     default = { onActivation = false; auto = { enable = false; onCalendar = "weekly"; }; };

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -245,8 +245,15 @@ in
   };
 
   overrides = mkOption {
-    #type = with types; coercedTo attrs (attrs: { inherit attrs; }) (submodule overridesOptions);
-    # type = with types; attrsOf (coercedTo attrs (attrs: { inherit attrs; }) (submodule overridesOptions));
+    # Accept both the legacy format (attrset of appId -> INI sections) and the submodule format.
+    # coercedTo detects the legacy shape and wraps it into { settings = <legacy>; } so downstream code
+    # always receives a consistent submodule value.
+    type = with types;
+      coercedTo
+        (addCheck (attrsOf (attrsOf (attrsOf (either str (listOf str)))))
+          (v: !(v ? settings || v ? files || v ? deleteOrphanedFiles)))
+        (legacySettings: { settings = legacySettings; })
+        (submodule overridesOptions);
     default = { };
     description = ''
       Applies the provided attribute set into a Flatpak overrides file with the

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -201,6 +201,16 @@ let
           ];
         '';
       };
+
+      deleteOrphanedFiles = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          When true, override files that are removed from configuration will be
+          deleted from the flatpak overrides directory. When false (default),
+          orphaned override files are preserved.
+        '';
+      };
     };
   };
 in

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -1,6 +1,9 @@
-{ config, lib, ... }:
-with lib;
-let
+{
+  config,
+  lib,
+  ...
+}:
+with lib; let
   remoteOptions = _: {
     options = {
       name = mkOption {
@@ -21,7 +24,7 @@ let
       args = mkOption {
         type = types.nullOr types.str;
         description = "Extra arguments to pass to flatpak remote-add.";
-        example = [ "--verbose" ];
+        example = ["--verbose"];
         default = null;
       };
     };
@@ -88,34 +91,39 @@ let
         description = ''
           Specification for the exponential backoff stategy to adopt in case of service failure.
         '';
-        type = with types; submodule (_: {
-          options = {
-            enable = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                Whether to enable exponential backoff in case of failure during installation or upgrade.
-              '';
-            };
+        type = with types;
+          submodule (_: {
+            options = {
+              enable = mkOption {
+                type = types.bool;
+                default = false;
+                description = ''
+                  Whether to enable exponential backoff in case of failure during installation or upgrade.
+                '';
+              };
 
-            steps = mkOption {
-              type = types.int;
-              default = 10;
-              description = ''
-                How many steps will be needed to reach the maximum restart delay.
-              '';
-            };
+              steps = mkOption {
+                type = types.int;
+                default = 10;
+                description = ''
+                  How many steps will be needed to reach the maximum restart delay.
+                '';
+              };
 
-            maxDelay = mkOption {
-              type = types.str;
-              default = "1h";
-              description = ''
-                Maximum delay (in as systemd timespan format) after which update or installation is going to be retried in case of failure.
-              '';
+              maxDelay = mkOption {
+                type = types.str;
+                default = "1h";
+                description = ''
+                  Maximum delay (in as systemd timespan format) after which update or installation is going to be retried in case of failure.
+                '';
+              };
             };
-          };
-        });
-        default = { enable = false; steps = 10; maxDelay = "1h"; };
+          });
+        default = {
+          enable = false;
+          steps = 10;
+          maxDelay = "1h";
+        };
       };
     };
   };
@@ -129,37 +137,38 @@ let
           Whether to enable flatpak to upgrade applications during
           {command}`nixos` system activation. The default is `false`
           so that repeated invocations of {command}`nixos-rebuild switch` are idempotent.
-          
+
           implementation: appends --or-update to each flatpak install command.
         '';
       };
       auto = mkOption {
-        type = with types; submodule (_: {
-          options = {
-            enable = mkOption {
-              type = types.bool;
-              default = false;
-              description = ''
-                Whether to enable flatpak to upgrade applications during
-                {command}`nixos` system activation, and scheudle periodic updates
-                afterwards.
-                
-                implementation: registers a systemd realtime timer that fires with an OnCalendar policy.
-                If a timer had expired while a machine was off/asleep, it will fire upon resume.
-                See https://wiki.archlinux.org/title/systemd/Timers for details.
-              '';
+        type = with types;
+          submodule (_: {
+            options = {
+              enable = mkOption {
+                type = types.bool;
+                default = false;
+                description = ''
+                  Whether to enable flatpak to upgrade applications during
+                  {command}`nixos` system activation, and scheudle periodic updates
+                  afterwards.
+
+                  implementation: registers a systemd realtime timer that fires with an OnCalendar policy.
+                  If a timer had expired while a machine was off/asleep, it will fire upon resume.
+                  See https://wiki.archlinux.org/title/systemd/Timers for details.
+                '';
+              };
+              onCalendar = mkOption {
+                type = types.str;
+                default = "weekly";
+                description = ''
+                  Frequency of periodic updates.
+                  See https://wiki.archlinux.org/title/systemd/Timers for details.
+                '';
+              };
             };
-            onCalendar = mkOption {
-              type = types.str;
-              default = "weekly";
-              description = ''
-                Frequency of periodic updates.
-                See https://wiki.archlinux.org/title/systemd/Timers for details.
-              '';
-            };
-          };
-        });
-        default = { enable = false; };
+          });
+        default = {enable = false;};
         description = ''
           Value(s) in this Nix set are used to configure the behavior of the auto updater.
         '';
@@ -171,7 +180,7 @@ let
     options = {
       settings = mkOption {
         type = with types; attrsOf (attrsOf (attrsOf (either str (listOf str))));
-        default = { };
+        default = {};
         description = ''
           Applies the provided attribute set into a Flatpak overrides file with the
           same structure, keeping externally applied changes.
@@ -187,8 +196,8 @@ let
       };
 
       files = mkOption {
-        type = with types; listOf str;
-        default = [ ];
+        type = with types; listOf (coercedTo path toString str);
+        default = [];
         description = ''
           A list of paths to Flatpak overrides files.
           The files will be merged with the overrides attribute set.
@@ -196,13 +205,15 @@ let
         '';
         example = literalExpression ''
           [
-            "/path/to/overrides.d/com.visualstudio.code"
+            # Nix path literal (pure evaluation)
+            ./overrides.d/com.visualstudio.code
+            # Plain string path (impure evaluation)
             "/path/to/overrides.d/org.gnome.Terminal"
           ];
         '';
       };
 
-      deleteOrphanedFiles = mkOption {
+      pruneUnmanagedOverrides = mkOption {
         type = types.bool;
         default = false;
         description = ''
@@ -211,13 +222,31 @@ let
           orphaned override files are preserved.
         '';
       };
+
+      writeMode = mkOption {
+        type = types.enum ["merge" "replace"];
+        default = "merge";
+        description = ''
+          Controls how Nix-managed override settings are written to the Flatpak
+          overrides directory.
+
+          - "merge" (default): at runtime, existing override files are read
+            and merged with Nix-managed settings. Direct user edits for
+            unmanaged keys are preserved across activations.
+
+          - "replace": the complete override file is computed at evaluation
+            time as a pure Nix derivation (settings merged with file-based
+            settings). At runtime, the pre-computed file is copied into the
+            overrides directory. Nix fully owns the file and any direct edits will
+            be discarded.
+        '';
+      };
     };
   };
-in
-{
+in {
   packages = mkOption {
-    type = with types; listOf (coercedTo str (appId: { inherit appId; }) (submodule packageOptions));
-    default = [ ];
+    type = with types; listOf (coercedTo str (appId: {inherit appId;}) (submodule packageOptions));
+    default = [];
     description = ''
       Declares a list of applications to install.
     '';
@@ -233,8 +262,13 @@ in
     '';
   };
   remotes = mkOption {
-    type = with types; listOf (coercedTo str (name: { inherit name location; }) (submodule remoteOptions));
-    default = [{ name = "flathub"; location = "https://dl.flathub.org/repo/flathub.flatpakrepo"; }];
+    type = with types; listOf (coercedTo str (name: {inherit name location;}) (submodule remoteOptions));
+    default = [
+      {
+        name = "flathub";
+        location = "https://dl.flathub.org/repo/flathub.flatpakrepo";
+      }
+    ];
     description = ''
       Declare a list of flatpak repositories.
     '';
@@ -250,11 +284,11 @@ in
     # always receives a consistent submodule value.
     type = with types;
       coercedTo
-        (addCheck (attrsOf (attrsOf (attrsOf (either str (listOf str)))))
-          (v: !(v ? settings || v ? files || v ? deleteOrphanedFiles)))
-        (legacySettings: { settings = legacySettings; })
-        (submodule overridesOptions);
-    default = { };
+      (addCheck (attrsOf (attrsOf (attrsOf (either str (listOf str)))))
+        (v: !(v ? settings || v ? files || v ? pruneUnmanagedOverrides)))
+      (legacySettings: {settings = legacySettings;})
+      (submodule overridesOptions);
+    default = {};
     description = ''
       Applies the provided attribute set into a Flatpak overrides file with the
       same structure, keeping externally applied changes.
@@ -271,17 +305,23 @@ in
 
   update = mkOption {
     type = with types; submodule updateOptions;
-    default = { onActivation = false; auto = { enable = false; onCalendar = "weekly"; }; };
+    default = {
+      onActivation = false;
+      auto = {
+        enable = false;
+        onCalendar = "weekly";
+      };
+    };
     description = ''
       Whether to enable flatpak to upgrade applications during
       {command}`nixos` system activation. The default is `false`
       so that repeated invocations of {command}`nixos-rebuild switch` are idempotent.
-      
+
       Applications pinned to a specific commit hash will not be updated.
-      
+
       If {command}`auto.enable = true` a periodic update will be scheduled with (approximately)
       weekly recurrence.
-      
+
       See https://wiki.archlinux.org/title/systemd/Timers for more information on systemd timers.
     '';
     example = literalExpression ''
@@ -304,8 +344,13 @@ in
 
   uninstallUnmanaged = mkOption {
     type = with types; bool;
-    default = (if isNull config.services.flatpak.uninstallUnmanagedPackages then false else
-    config.services.flatpak.uninstallUnmanagedPackages) || false;
+    default =
+      (
+        if isNull config.services.flatpak.uninstallUnmanagedPackages
+        then false
+        else config.services.flatpak.uninstallUnmanagedPackages
+      )
+      || false;
     description = ''
       If enabled, uninstall packages and delete remotes not managed by this module on activation.
       I.e. if packages were installed via Flatpak directly instead of this module,
@@ -315,7 +360,15 @@ in
 
   restartOnFailure = mkOption {
     type = with types; submodule restartOptions;
-    default = { enable = true; restartDelay = "60s"; exponentialBackoff = { enable = false; steps = 10; maxDelay = "1h"; }; };
+    default = {
+      enable = true;
+      restartDelay = "60s";
+      exponentialBackoff = {
+        enable = false;
+        steps = 10;
+        maxDelay = "1h";
+      };
+    };
     description = ''
       If enabled, restart the flatpak-managed-install service in case of failure.
       It is possible to specify a restart delay and an exponential backoff strategy.
@@ -329,6 +382,5 @@ in
       If enabled, uninstalls unused packages and runtimes.
       Defaults to `config.services.flatpak.uninstallUnmanaged`, or `false`.
     '';
-
   };
 }

--- a/tests/fixtures/overrides/com.other.app
+++ b/tests/fixtures/overrides/com.other.app
@@ -1,0 +1,2 @@
+[Context]
+shared=network

--- a/tests/fixtures/overrides/org.gnome.Terminal
+++ b/tests/fixtures/overrides/org.gnome.Terminal
@@ -1,0 +1,2 @@
+[Context]
+sockets=wayland;!x11

--- a/tests/ini-tests.nix
+++ b/tests/ini-tests.nix
@@ -1,0 +1,110 @@
+{pkgs ? import <nixpkgs> {}}: let
+  inherit (pkgs) lib;
+  inherit (lib) runTests;
+
+  ini = import ../modules/flatpak/ini.nix {inherit lib;};
+  inherit (ini) parseIniContent toIniContent;
+
+  fixtureGlobal = "[Environment]\nLC_ALL = \"C.UTF-8\"\n";
+  fixtureGedit = "[Context]\nsockets=wayland;!x11;fallback-x11;\n";
+  fixtureOnlyOffice = "[Context]\nsockets=x11";
+
+  # The roundtrip property we verify throughout:
+  # parse(serialize(parse(content))) == parse(content)
+  # This confirms that toIniContent produces valid INI that parses back to the same
+  # structure, and implicitly that the parser is idempotent on canonical output.
+  roundtrip = content: parseIniContent (toIniContent (parseIniContent content));
+in
+  runTests {
+    testParseSingleStringValue = {
+      expr = parseIniContent "[Context]\nsockets=x11\n";
+      expected = {Context = {sockets = "x11";};};
+    };
+
+    testParseMultipleValues = {
+      expr = parseIniContent "[Context]\nsockets=wayland;!x11;fallback-x11\n";
+      expected = {Context = {sockets = ["wayland" "!x11" "fallback-x11"];};};
+    };
+
+    testParseMultipleSections = {
+      expr = parseIniContent "[Context]\nshared=network\n[Environment]\nLANG=C.UTF-8\n";
+      expected = {
+        Context = {shared = "network";};
+        Environment = {LANG = "C.UTF-8";};
+      };
+    };
+
+    testParseTrimsKeyWhitespace = {
+      expr = (parseIniContent "[Environment]\nLC_ALL = \"C.UTF-8\"\n").Environment;
+      expected = {LC_ALL = "\"C.UTF-8\"";};
+    };
+
+    testParseIgnoresBlankLines = {
+      expr = parseIniContent "\n[Context]\n\nsockets=x11\n\n";
+      expected = {Context = {sockets = "x11";};};
+    };
+
+    testParseIgnoresHashComments = {
+      expr = parseIniContent "# a comment\n[Context]\nsockets=x11\n";
+      expected = {Context = {sockets = "x11";};};
+    };
+
+    testParseIgnoresSemicolonComments = {
+      expr = parseIniContent "; a comment\n[Context]\nsockets=x11\n";
+      expected = {Context = {sockets = "x11";};};
+    };
+
+    testParseStripsTrailingSemicolon = {
+      # Flatpak sometimes writes a trailing semicolon; parser must drop the empty token.
+      expr = parseIniContent "[Context]\nsockets=wayland;!x11;fallback-x11;\n";
+      expected = {Context = {sockets = ["wayland" "!x11" "fallback-x11"];};};
+    };
+
+    testValueOrderPreserved = {
+      # "ordering of values matter": wayland must come before !x11 before fallback-x11.
+      expr = (parseIniContent "[Context]\nsockets=wayland;!x11;fallback-x11;\n").Context.sockets;
+      expected = ["wayland" "!x11" "fallback-x11"];
+    };
+
+    testValueOrderNotAlphabetical = {
+      # Values should NOT be sorted – original declaration order is kept.
+      expr = (parseIniContent "[Context]\nsockets=z;a;m;\n").Context.sockets;
+      expected = ["z" "a" "m"];
+    };
+
+    testParseFixtureGlobal = {
+      expr = parseIniContent fixtureGlobal;
+      expected = {Environment = {LC_ALL = "\"C.UTF-8\"";};};
+    };
+
+    testParseFixtureGedit = {
+      expr = parseIniContent fixtureGedit;
+      expected = {Context = {sockets = ["wayland" "!x11" "fallback-x11"];};};
+    };
+
+    testParseFixtureOnlyOffice = {
+      expr = parseIniContent fixtureOnlyOffice;
+      expected = {Context = {sockets = "x11";};};
+    };
+
+    testRoundtripGlobal = {
+      expr = roundtrip fixtureGlobal;
+      expected = parseIniContent fixtureGlobal;
+    };
+
+    testRoundtripGedit = {
+      expr = roundtrip fixtureGedit;
+      expected = parseIniContent fixtureGedit;
+    };
+
+    testRoundtripOnlyOffice = {
+      expr = roundtrip fixtureOnlyOffice;
+      expected = parseIniContent fixtureOnlyOffice;
+    };
+
+    # Roundtrip must preserve values order and not sort them.
+    testRoundtripPreservesGeditSocketOrder = {
+      expr = (roundtrip fixtureGedit).Context.sockets;
+      expected = ["wayland" "!x11" "fallback-x11"];
+    };
+  }

--- a/tests/state/ini-test.nix
+++ b/tests/state/ini-test.nix
@@ -1,0 +1,161 @@
+{ pkgs ? import <nixpkgs> { } }:
+let
+  inherit (pkgs) lib;
+  inherit (lib) runTests;
+
+  ini = import ../../modules/flatpak/ini.nix { inherit lib; };
+  inherit (ini) parseIniContent toIniContent mergeOverrideSettings;
+
+  roundtrip = content: parseIniContent (toIniContent (parseIniContent content));
+in
+runTests {
+
+  # ---------------------------------------------------------------------------
+  # parseIniContent
+  # ---------------------------------------------------------------------------
+
+  testParseBasicSectionKey = {
+    expr     = parseIniContent "[Context]\nshared=network\n";
+    expected = { Context = { shared = "network"; }; };
+  };
+
+  testParseSemicolonSeparatedBecomesList = {
+    expr     = parseIniContent "[Context]\nsockets=wayland;!x11\n";
+    expected = { Context = { sockets = [ "wayland" "!x11" ]; }; };
+  };
+
+  testParseSingleValueStaysString = {
+    expr     = parseIniContent "[Context]\nsockets=x11\n";
+    expected = { Context = { sockets = "x11"; }; };
+  };
+
+  testParseBlankLinesIgnored = {
+    expr     = parseIniContent "\n[Context]\n\nsockets=x11\n\n";
+    expected = { Context = { sockets = "x11"; }; };
+  };
+
+  testParseHashCommentIgnored = {
+    expr     = parseIniContent "# comment\n[Context]\nsockets=x11\n";
+    expected = { Context = { sockets = "x11"; }; };
+  };
+
+  testParseWhitespaceTrimmed = {
+    expr     = parseIniContent "[Context]\nshared = network\n";
+    expected = { Context = { shared = "network"; }; };
+  };
+
+  # ---------------------------------------------------------------------------
+  # toIniContent
+  # ---------------------------------------------------------------------------
+
+  testToIniSectionsSortedAlphabetically = {
+    expr     = builtins.substring 0 3 (toIniContent { Z = { a = "1"; }; A = { b = "2"; }; });
+    expected = "[A]";
+  };
+
+  testToIniKeysSortedAlphabetically = {
+    # keys z and a: a must appear before z in output
+    expr =
+      let out = toIniContent { Context = { z = "1"; a = "2"; }; };
+      in (builtins.match ".*\na=.*" out) != null;
+    expected = true;
+  };
+
+  testToIniListJoinedWithSemicolon = {
+    expr     = toIniContent { Context = { sockets = [ "wayland" "!x11" ]; }; };
+    expected = "[Context]\nsockets=wayland;!x11\n";
+  };
+
+  testToIniSectionsSeparatedByBlankLine = {
+    # Two sections must be separated by a blank line (\n\n between them)
+    expr =
+      let out = toIniContent { A = { k = "1"; }; B = { k = "2"; }; };
+      in lib.strings.hasInfix "\n\n" out;
+    expected = true;
+  };
+
+  # ---------------------------------------------------------------------------
+  # mergeOverrideSettings
+  # ---------------------------------------------------------------------------
+
+  testMergeSettingsWinsOverFileSettings = {
+    expr = mergeOverrideSettings
+      { "com.example.app" = { Context = { shared = "ipc"; }; }; }
+      { "com.example.app" = { Context = { shared = "network"; devices = "dri"; }; }; }
+      "com.example.app";
+    # settings shared=ipc wins; fileSettings devices=dri is preserved
+    expected = { Context = { shared = "ipc"; devices = "dri"; }; };
+  };
+
+  testMergeFileSettingsUsedWhenSettingsAbsent = {
+    expr = mergeOverrideSettings
+      { }
+      { "com.example.app" = { Context = { shared = "network"; }; }; }
+      "com.example.app";
+    expected = { Context = { shared = "network"; }; };
+  };
+
+  testMergeSettingsOnly = {
+    expr = mergeOverrideSettings
+      { "com.example.app" = { Context = { shared = "ipc"; }; }; }
+      { }
+      "com.example.app";
+    expected = { Context = { shared = "ipc"; }; };
+  };
+
+  testMergeFileSettingsOnly = {
+    expr = mergeOverrideSettings
+      { }
+      { "com.example.app" = { Context = { shared = "network"; }; }; }
+      "com.example.app";
+    expected = { Context = { shared = "network"; }; };
+  };
+
+  testMergeBothEmpty = {
+    expr     = mergeOverrideSettings { } { } "com.example.app";
+    expected = { };
+  };
+
+  testMergeMultipleSections = {
+    expr = mergeOverrideSettings
+      { "com.example.app" = { Environment = { LANG = "en_US.UTF-8"; }; }; }
+      { "com.example.app" = { Context = { shared = "network"; }; }; }
+      "com.example.app";
+    expected = {
+      Context     = { shared = "network"; };
+      Environment = { LANG = "en_US.UTF-8"; };
+    };
+  };
+
+  testMergeUnknownAppReturnsEmpty = {
+    expr = mergeOverrideSettings
+      { "com.example.app" = { Context = { shared = "ipc"; }; }; }
+      { }
+      "com.other.app";
+    expected = { };
+  };
+
+  # ---------------------------------------------------------------------------
+  # Roundtrip: parse ∘ toIni ∘ parse == parse (inline strings only)
+  # ---------------------------------------------------------------------------
+
+  testRoundtripSingleSection = {
+    expr     = roundtrip "[Context]\nshared=network\n";
+    expected = parseIniContent "[Context]\nshared=network\n";
+  };
+
+  testRoundtripMultipleValues = {
+    expr     = roundtrip "[Context]\nsockets=wayland;!x11;fallback-x11;\n";
+    expected = parseIniContent "[Context]\nsockets=wayland;!x11;fallback-x11;\n";
+  };
+
+  testRoundtripMultipleSections = {
+    expr     = roundtrip "[Context]\nshared=network\n[Environment]\nLANG=C.UTF-8\n";
+    expected = parseIniContent "[Context]\nshared=network\n[Environment]\nLANG=C.UTF-8\n";
+  };
+
+  testRoundtripPreservesValueOrder = {
+    expr     = (roundtrip "[Context]\nsockets=z;a;m;\n").Context.sockets;
+    expected = [ "z" "a" "m" ];
+  };
+}

--- a/tests/state/legacy-overrides-test.nix
+++ b/tests/state/legacy-overrides-test.nix
@@ -160,4 +160,74 @@ runTests {
     ];
     expected = true;
   };
+
+  # Throw when two patchs contain duplicated basenames.
+  testDuplicateBasenamesThrows = {
+    expr = builtins.tryEval (
+      (import ../../modules/flatpak/install.nix {
+        cfg = baseConfig // {
+          overrides = {
+            files = [
+              "/path/a/com.example.app"
+              "/path/b/com.example.app"
+            ];
+          };
+        };
+        inherit pkgs lib installation;
+        executionContext = "service-start";
+      }).mkOverridesCmd
+    );
+    expected = { success = false; value = false; };
+  };
+
+  # Throw if path contains newline.
+  testPathWithNewlineThrows = {
+    expr = builtins.tryEval (
+      (import ../../modules/flatpak/install.nix {
+        cfg = baseConfig // {
+          overrides = {
+            files = [ "/path/to/com.example\napp" ];
+          };
+        };
+        inherit pkgs lib installation;
+        executionContext = "service-start";
+      }).mkOverridesCmd
+    );
+    expected = { success = false; value = false; };
+  };
+
+  # Throw if path contains single quote.
+  testPathWithSingleQuoteThrows = {
+    expr = builtins.tryEval (
+      (import ../../modules/flatpak/install.nix {
+        cfg = baseConfig // {
+          overrides = {
+            files = [ "/path/to/com.example'app" ];
+          };
+        };
+        inherit pkgs lib installation;
+        executionContext = "service-start";
+      }).mkOverridesCmd
+    );
+    expected = { success = false; value = false; };
+  };
+
+  # Two distinct basenames must succeed.
+  testValidUniquePathsSucceed = {
+    expr = builtins.isString (
+      (import ../../modules/flatpak/install.nix {
+        cfg = baseConfig // {
+          overrides = {
+            files = [
+              "/path/a/com.example.app"
+              "/path/b/org.gnome.Terminal"
+            ];
+          };
+        };
+        inherit pkgs lib installation;
+        executionContext = "service-start";
+      }).mkOverridesCmd
+    );
+    expected = true;
+  };
 }

--- a/tests/state/legacy-overrides-test.nix
+++ b/tests/state/legacy-overrides-test.nix
@@ -1,74 +1,115 @@
 # Tests for legacy override format backward compatibility.
 # Verifies that install.nix can be evaluated when using the legacy format
-# where overrides is just an attrset of settings (without .files or .deleteOrphanedFiles).
-{ pkgs ? import <nixpkgs> { } }:
-let
+# where overrides is just an attrset of settings (without .files or .pruneUnmanagedOverrides).
+{pkgs ? import <nixpkgs> {}}: let
   inherit (pkgs) lib;
   inherit (lib) runTests;
   installation = "user";
 
-  # Base config with proper package attributes
   baseConfig = {
     update = {
       onActivation = false;
-      auto = { enable = false; };
+      auto = {enable = false;};
     };
-    remotes = [{ name = "some-remote"; location = "https://some.remote.tld/repo/test-remote.flatpakrepo"; }];
-    packages = [{ appId = "SomeAppId"; origin = "some-remote"; bundle = null; sha256 = null; }];
+    remotes = [
+      {
+        name = "some-remote";
+        location = "https://some.remote.tld/repo/test-remote.flatpakrepo";
+      }
+    ];
+    packages = [
+      {
+        appId = "SomeAppId";
+        origin = "some-remote";
+        bundle = null;
+        sha256 = null;
+      }
+    ];
     uninstallUnmanaged = false;
     uninstallUnused = false;
   };
 
   # Legacy format: overrides is just an attrset of app settings
-  # (no .files, .settings, or .deleteOrphanedFiles attributes)
-  cfgLegacyOverrides = baseConfig // {
-    overrides = {
-      "com.example.app" = {
-        "Context" = { "shared" = "network"; };
-      };
-    };
-  };
-
-  # New format with only settings (no files or deleteOrphanedFiles)
-  cfgNewFormatSettingsOnly = baseConfig // {
-    overrides = {
-      settings = {
+  # (no .files, .settings, or .pruneUnmanagedOverrides attributes)
+  cfgLegacyOverrides =
+    baseConfig
+    // {
+      overrides = {
         "com.example.app" = {
-          "Context" = { "shared" = "network"; };
+          "Context" = {"shared" = "network";};
         };
       };
     };
-  };
 
-  # New format with files but no deleteOrphanedFiles
-  cfgNewFormatWithFiles = baseConfig // {
-    overrides = {
-      settings = {
-        "com.example.app" = {
-          "Context" = { "shared" = "network"; };
+  # New format with only settings (no files or pruneUnmanagedOverrides)
+  cfgNewFormatSettingsOnly =
+    baseConfig
+    // {
+      overrides = {
+        settings = {
+          "com.example.app" = {
+            "Context" = {"shared" = "network";};
+          };
         };
       };
-      files = [ "/path/to/com.other.app" ];
     };
-  };
+
+  # New format with files but no pruneUnmanagedOverrides
+  cfgNewFormatWithFiles =
+    baseConfig
+    // {
+      overrides = {
+        settings = {
+          "com.example.app" = {
+            "Context" = {"shared" = "network";};
+          };
+        };
+        files = [(toString ../fixtures/overrides/com.other.app)];
+      };
+    };
 
   # Full new format
-  cfgFullNewFormat = baseConfig // {
-    overrides = {
-      settings = {
-        "com.example.app" = {
-          "Context" = { "shared" = "network"; };
+  cfgFullNewFormat =
+    baseConfig
+    // {
+      overrides = {
+        settings = {
+          "com.example.app" = {
+            "Context" = {"shared" = "network";};
+          };
         };
+        files = [(toString ../fixtures/overrides/com.other.app)];
+        pruneUnmanagedOverrides = true;
       };
-      files = [ "/path/to/com.other.app" ];
-      deleteOrphanedFiles = true;
     };
-  };
+
+  # writeMode = "merge" explicit
+  cfgWriteModeMerge =
+    baseConfig
+    // {
+      overrides = {
+        writeMode = "merge";
+        settings = {"com.example.app" = {"Context" = {"shared" = "network";};};};
+      };
+    };
+
+  # writeMode = "replace"
+  cfgWriteModeReplace =
+    baseConfig
+    // {
+      overrides = {
+        writeMode = "replace";
+        settings = {"com.example.app" = {"Context" = {"shared" = "network";};};};
+        files = [(toString ../fixtures/overrides/com.other.app)];
+      };
+    };
 
   # Empty overrides (common case)
-  cfgEmptyOverrides = baseConfig // {
-    overrides = { };
-  };
+  cfgEmptyOverrides =
+    baseConfig
+    // {
+      overrides = {};
+    };
 
   installLegacy = import ../../modules/flatpak/install.nix {
     cfg = cfgLegacyOverrides;
@@ -99,135 +140,205 @@ let
     inherit pkgs lib installation;
     executionContext = "service-start";
   };
+
+  installWriteModeMerge = import ../../modules/flatpak/install.nix {
+    cfg = cfgWriteModeMerge;
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
+
+  installWriteModeReplace = import ../../modules/flatpak/install.nix {
+    cfg = cfgWriteModeReplace;
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
 in
-runTests {
-  # Test that legacy format evaluates without error
-  # Cechks that mkOverridesCmd can be generated (uses cfg.overrides.files and cfg.overrides.deleteOrphanedFiles)
-  testLegacyOverridesEvaluates = {
-    expr = builtins.isString installLegacy.mkOverridesCmd;
-    expected = true;
-  };
+  runTests {
+    testLegacyOverridesEvaluates = {
+      expr = builtins.isString installLegacy.mkOverridesCmd;
+      expected = true;
+    };
 
-  # Test new format with only settings (no files/deleteOrphanedFiles) evaluates
-  testNewFormatSettingsOnlyEvaluates = {
-    expr = builtins.isString installNewSettingsOnly.mkOverridesCmd;
-    expected = true;
-  };
+    testNewFormatSettingsOnlyEvaluates = {
+      expr = builtins.isString installNewSettingsOnly.mkOverridesCmd;
+      expected = true;
+    };
 
-  # Test new format with files but no deleteOrphanedFiles evaluates
-  testNewFormatWithFilesEvaluates = {
-    expr = builtins.isString installNewWithFiles.mkOverridesCmd;
-    expected = true;
-  };
+    testNewFormatWithFilesEvaluates = {
+      expr = builtins.isString installNewWithFiles.mkOverridesCmd;
+      expected = true;
+    };
 
-  # Test full new format evaluates
-  testFullNewFormatEvaluates = {
-    expr = builtins.isString installFullNew.mkOverridesCmd;
-    expected = true;
-  };
+    testFullNewFormatEvaluates = {
+      expr = builtins.isString installFullNew.mkOverridesCmd;
+      expected = true;
+    };
 
-  # Test empty overrides evaluates
-  testEmptyOverridesEvaluates = {
-    expr = builtins.isString installEmpty.mkOverridesCmd;
-    expected = true;
-  };
+    testEmptyOverridesEvaluates = {
+      expr = builtins.isString installEmpty.mkOverridesCmd;
+      expected = true;
+    };
 
-  # Test that mkSaveStateCmd can be generated for legacy format
-  testLegacyOverridesMkSaveStateCmdEvaluates = {
-    expr = builtins.isString installLegacy.mkSaveStateCmd;
-    expected = true;
-  };
+    testLegacyOverridesMkSaveStateCmdEvaluates = {
+      expr = builtins.isString installLegacy.mkSaveStateCmd;
+      expected = true;
+    };
 
-  # Test that mkSaveStateCmd can be generated for empty overrides
-  testEmptyOverridesMkSaveStateCmdEvaluates = {
-    expr = builtins.isString installEmpty.mkSaveStateCmd;
-    expected = true;
-  };
+    testEmptyOverridesMkSaveStateCmdEvaluates = {
+      expr = builtins.isString installEmpty.mkSaveStateCmd;
+      expected = true;
+    };
 
-  # Test that mkInstallCmd can be generated for legacy format
-  testLegacyOverridesMkInstallCmdEvaluates = {
-    expr = builtins.isString installLegacy.mkInstallCmd;
-    expected = true;
-  };
+    testLegacyOverridesMkInstallCmdEvaluates = {
+      expr = builtins.isString installLegacy.mkInstallCmd;
+      expected = true;
+    };
 
-  # Test that all commands can be generated for full new format
-  testFullNewFormatAllCommandsEvaluate = {
-    expr = builtins.all (x: builtins.isString x) [
-      installFullNew.mkOverridesCmd
-      installFullNew.mkSaveStateCmd
-      installFullNew.mkInstallCmd
-      installFullNew.mkLoadStateCmd
-    ];
-    expected = true;
-  };
+    testFullNewFormatAllCommandsEvaluate = {
+      expr = builtins.all (x: builtins.isString x) [
+        installFullNew.mkOverridesCmd
+        installFullNew.mkSaveStateCmd
+        installFullNew.mkInstallCmd
+        installFullNew.mkLoadStateCmd
+      ];
+      expected = true;
+    };
 
-  # Throw when two patchs contain duplicated basenames.
-  testDuplicateBasenamesThrows = {
-    expr = builtins.tryEval (
-      (import ../../modules/flatpak/install.nix {
-        cfg = baseConfig // {
-          overrides = {
-            files = [
-              "/path/a/com.example.app"
-              "/path/b/com.example.app"
-            ];
-          };
-        };
-        inherit pkgs lib installation;
-        executionContext = "service-start";
-      }).mkOverridesCmd
-    );
-    expected = { success = false; value = false; };
-  };
+    testDuplicateBasenamesThrows = {
+      expr = builtins.tryEval (
+        (import ../../modules/flatpak/install.nix {
+          cfg =
+            baseConfig
+            // {
+              overrides = {
+                files = [
+                  "/path/a/com.example.app"
+                  "/path/b/com.example.app"
+                ];
+              };
+            };
+          inherit pkgs lib installation;
+          executionContext = "service-start";
+        }).mkSaveStateCmd
+      );
+      expected = {
+        success = false;
+        value = false;
+      };
+    };
 
-  # Throw if path contains newline.
-  testPathWithNewlineThrows = {
-    expr = builtins.tryEval (
-      (import ../../modules/flatpak/install.nix {
-        cfg = baseConfig // {
-          overrides = {
-            files = [ "/path/to/com.example\napp" ];
-          };
-        };
-        inherit pkgs lib installation;
-        executionContext = "service-start";
-      }).mkOverridesCmd
-    );
-    expected = { success = false; value = false; };
-  };
+    testPathWithNewlineThrows = {
+      expr = builtins.tryEval (
+        (import ../../modules/flatpak/install.nix {
+          cfg =
+            baseConfig
+            // {
+              overrides = {
+                files = ["/path/to/com.example\napp"];
+              };
+            };
+          inherit pkgs lib installation;
+          executionContext = "service-start";
+        }).mkSaveStateCmd
+      );
+      expected = {
+        success = false;
+        value = false;
+      };
+    };
 
-  # Throw if path contains single quote.
-  testPathWithSingleQuoteThrows = {
-    expr = builtins.tryEval (
-      (import ../../modules/flatpak/install.nix {
-        cfg = baseConfig // {
-          overrides = {
-            files = [ "/path/to/com.example'app" ];
-          };
-        };
-        inherit pkgs lib installation;
-        executionContext = "service-start";
-      }).mkOverridesCmd
-    );
-    expected = { success = false; value = false; };
-  };
+    testPathWithSingleQuoteThrows = {
+      expr = builtins.tryEval (
+        (import ../../modules/flatpak/install.nix {
+          cfg =
+            baseConfig
+            // {
+              overrides = {
+                files = ["/path/to/com.example'app"];
+              };
+            };
+          inherit pkgs lib installation;
+          executionContext = "service-start";
+        }).mkSaveStateCmd
+      );
+      expected = {
+        success = false;
+        value = false;
+      };
+    };
 
-  # Two distinct basenames must succeed.
-  testValidUniquePathsSucceed = {
-    expr = builtins.isString (
-      (import ../../modules/flatpak/install.nix {
-        cfg = baseConfig // {
-          overrides = {
-            files = [
-              "/path/a/com.example.app"
-              "/path/b/org.gnome.Terminal"
-            ];
-          };
-        };
-        inherit pkgs lib installation;
-        executionContext = "service-start";
-      }).mkOverridesCmd
-    );
-    expected = true;
-  };
-}
+    testPathWithCarriageReturnThrows = {
+      expr = builtins.tryEval (
+        (import ../../modules/flatpak/install.nix {
+          cfg =
+            baseConfig
+            // {
+              overrides = {
+                files = ["/path/to/com.example\rapp"];
+              };
+            };
+          inherit pkgs lib installation;
+          executionContext = "service-start";
+        }).mkSaveStateCmd
+      );
+      expected = {
+        success = false;
+        value = false;
+      };
+    };
+
+    testPathWithNullByteThrows = {
+      expr = builtins.tryEval (
+        (import ../../modules/flatpak/install.nix {
+          cfg =
+            baseConfig
+            // {
+              overrides = {
+                files = ["/path/to/com.example\x00app"];
+              };
+            };
+          inherit pkgs lib installation;
+          executionContext = "service-start";
+        }).mkSaveStateCmd
+      );
+      expected = {
+        success = false;
+        value = false;
+      };
+    };
+
+    testWriteModeMergeEvaluates = {
+      expr = builtins.isString installWriteModeMerge.mkOverridesCmd;
+      expected = true;
+    };
+
+    testWriteModeReplaceEvaluates = {
+      expr = builtins.isString installWriteModeReplace.mkOverridesCmd;
+      expected = true;
+    };
+
+    testDefaultWriteModeIsMerge = {
+      expr = lib.strings.hasInfix "cp --no-preserve" installNewSettingsOnly.mkOverridesCmd;
+      expected = false;
+    };
+
+    testValidUniquePathsSucceed = {
+      expr = builtins.isString (
+        (import ../../modules/flatpak/install.nix {
+          cfg =
+            baseConfig
+            // {
+              overrides = {
+                files = [
+                  (toString ../fixtures/overrides/com.other.app)
+                  (toString ../fixtures/overrides/org.gnome.Terminal)
+                ];
+              };
+            };
+          inherit pkgs lib installation;
+          executionContext = "service-start";
+        }).mkSaveStateCmd
+      );
+      expected = true;
+    };
+  }

--- a/tests/state/legacy-overrides-test.nix
+++ b/tests/state/legacy-overrides-test.nix
@@ -1,0 +1,163 @@
+# Tests for legacy override format backward compatibility.
+# Verifies that install.nix can be evaluated when using the legacy format
+# where overrides is just an attrset of settings (without .files or .deleteOrphanedFiles).
+{ pkgs ? import <nixpkgs> { } }:
+let
+  inherit (pkgs) lib;
+  inherit (lib) runTests;
+  installation = "user";
+
+  # Base config with proper package attributes
+  baseConfig = {
+    update = {
+      onActivation = false;
+      auto = { enable = false; };
+    };
+    remotes = [{ name = "some-remote"; location = "https://some.remote.tld/repo/test-remote.flatpakrepo"; }];
+    packages = [{ appId = "SomeAppId"; origin = "some-remote"; bundle = null; sha256 = null; }];
+    uninstallUnmanaged = false;
+    uninstallUnused = false;
+  };
+
+  # Legacy format: overrides is just an attrset of app settings
+  # (no .files, .settings, or .deleteOrphanedFiles attributes)
+  cfgLegacyOverrides = baseConfig // {
+    overrides = {
+      "com.example.app" = {
+        "Context" = { "shared" = "network"; };
+      };
+    };
+  };
+
+  # New format with only settings (no files or deleteOrphanedFiles)
+  cfgNewFormatSettingsOnly = baseConfig // {
+    overrides = {
+      settings = {
+        "com.example.app" = {
+          "Context" = { "shared" = "network"; };
+        };
+      };
+    };
+  };
+
+  # New format with files but no deleteOrphanedFiles
+  cfgNewFormatWithFiles = baseConfig // {
+    overrides = {
+      settings = {
+        "com.example.app" = {
+          "Context" = { "shared" = "network"; };
+        };
+      };
+      files = [ "/path/to/com.other.app" ];
+    };
+  };
+
+  # Full new format
+  cfgFullNewFormat = baseConfig // {
+    overrides = {
+      settings = {
+        "com.example.app" = {
+          "Context" = { "shared" = "network"; };
+        };
+      };
+      files = [ "/path/to/com.other.app" ];
+      deleteOrphanedFiles = true;
+    };
+  };
+
+  # Empty overrides (common case)
+  cfgEmptyOverrides = baseConfig // {
+    overrides = { };
+  };
+
+  installLegacy = import ../../modules/flatpak/install.nix {
+    cfg = cfgLegacyOverrides;
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
+
+  installNewSettingsOnly = import ../../modules/flatpak/install.nix {
+    cfg = cfgNewFormatSettingsOnly;
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
+
+  installNewWithFiles = import ../../modules/flatpak/install.nix {
+    cfg = cfgNewFormatWithFiles;
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
+
+  installFullNew = import ../../modules/flatpak/install.nix {
+    cfg = cfgFullNewFormat;
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
+
+  installEmpty = import ../../modules/flatpak/install.nix {
+    cfg = cfgEmptyOverrides;
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
+in
+runTests {
+  # Test that legacy format evaluates without error
+  # Cechks that mkOverridesCmd can be generated (uses cfg.overrides.files and cfg.overrides.deleteOrphanedFiles)
+  testLegacyOverridesEvaluates = {
+    expr = builtins.isString installLegacy.mkOverridesCmd;
+    expected = true;
+  };
+
+  # Test new format with only settings (no files/deleteOrphanedFiles) evaluates
+  testNewFormatSettingsOnlyEvaluates = {
+    expr = builtins.isString installNewSettingsOnly.mkOverridesCmd;
+    expected = true;
+  };
+
+  # Test new format with files but no deleteOrphanedFiles evaluates
+  testNewFormatWithFilesEvaluates = {
+    expr = builtins.isString installNewWithFiles.mkOverridesCmd;
+    expected = true;
+  };
+
+  # Test full new format evaluates
+  testFullNewFormatEvaluates = {
+    expr = builtins.isString installFullNew.mkOverridesCmd;
+    expected = true;
+  };
+
+  # Test empty overrides evaluates
+  testEmptyOverridesEvaluates = {
+    expr = builtins.isString installEmpty.mkOverridesCmd;
+    expected = true;
+  };
+
+  # Test that mkSaveStateCmd can be generated for legacy format
+  testLegacyOverridesMkSaveStateCmdEvaluates = {
+    expr = builtins.isString installLegacy.mkSaveStateCmd;
+    expected = true;
+  };
+
+  # Test that mkSaveStateCmd can be generated for empty overrides
+  testEmptyOverridesMkSaveStateCmdEvaluates = {
+    expr = builtins.isString installEmpty.mkSaveStateCmd;
+    expected = true;
+  };
+
+  # Test that mkInstallCmd can be generated for legacy format
+  testLegacyOverridesMkInstallCmdEvaluates = {
+    expr = builtins.isString installLegacy.mkInstallCmd;
+    expected = true;
+  };
+
+  # Test that all commands can be generated for full new format
+  testFullNewFormatAllCommandsEvaluate = {
+    expr = builtins.all (x: builtins.isString x) [
+      installFullNew.mkOverridesCmd
+      installFullNew.mkSaveStateCmd
+      installFullNew.mkInstallCmd
+      installFullNew.mkLoadStateCmd
+    ];
+    expected = true;
+  };
+}

--- a/tests/state/overrides-test.nix
+++ b/tests/state/overrides-test.nix
@@ -40,8 +40,8 @@ runTests {
   testNoChanges = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
       activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
     };
     expected = "[Context]\nshared=network\n\n";
@@ -50,8 +50,8 @@ runTests {
   testNewOverrideAdded = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = {}; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = {}; }; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
       activeState = builtins.toJSON { };
     };
     expected = "[Context]\nshared=network\n\n";
@@ -60,8 +60,8 @@ runTests {
   testOverrideRemoved = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = {}; }; };
+      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = {}; }; };
       activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
     };
     expected = "";
@@ -70,8 +70,8 @@ runTests {
   testOverrideUpdated = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; }; };
       activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
     };
     expected = "[Context]\nshared=ipc\n\n";
@@ -80,8 +80,8 @@ runTests {
   testMultipleSections = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network;ipc"; }; "Permissions" = { "devices" = "all"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network;ipc"; }; "Permissions" = { "devices" = "all"; }; }; }; };
       activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
     };
     expected = "[Context]\nshared=network;ipc\n\n[Permissions]\ndevices=all\n\n";
@@ -91,8 +91,8 @@ runTests {
   testBaseOverridesOnly = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = {}; };
-      newState = builtins.toJSON { overrides = {}; };
+      oldState = builtins.toJSON { overrides.settings = {}; };
+      newState = builtins.toJSON { overrides.settings = {}; };
       activeState = builtins.toJSON { };
       baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; "devices" = "dri"; }; };
     };
@@ -102,8 +102,8 @@ runTests {
   testBaseOverridesWithStateChanges = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = {}; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; "Permissions" = { "filesystems" = "home"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = {}; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; "Permissions" = { "filesystems" = "home"; }; }; }; };
       activeState = builtins.toJSON { };
       baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; "devices" = "dri"; }; };
     };
@@ -113,8 +113,8 @@ runTests {
   testBaseOverridesWithArrayMerging = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = {}; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = [ "ipc" ]; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = {}; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "ipc" ]; }; }; }; };
       activeState = builtins.toJSON { };
       baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "network" ]; "devices" = [ "dri" ]; }; };
     };
@@ -124,8 +124,8 @@ runTests {
   testBaseOverridesWithOldStateRemoval = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "x11"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; }; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "x11"; }; }; }; };
       activeState = builtins.toJSON { "Context" = { "shared" = [ "network" "ipc" ]; }; };
       baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "network" ]; "devices" = [ "dri" ]; }; };
     };
@@ -135,8 +135,8 @@ runTests {
   testBaseOverridesOverriddenByState = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = {}; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "x11"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = {}; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "x11"; }; }; }; };
       activeState = builtins.toJSON { };
       baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; "devices" = "dri"; }; };
     };
@@ -146,8 +146,8 @@ runTests {
   testComplexMergeScenario = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; "Permissions" = { "devices" = "all"; }; }; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = [ "ipc" "x11" ]; }; "Environment" = { "LANG" = "en_US.UTF-8"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; "Permissions" = { "devices" = "all"; }; }; }; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "ipc" "x11" ]; }; "Environment" = { "LANG" = "en_US.UTF-8"; }; }; }; };
       activeState = builtins.toJSON { "Context" = { "shared" = [ "network" "pulseaudio" ]; }; "Permissions" = { "devices" = "all"; }; };
       baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "pulseaudio" ]; "devices" = [ "dri" ]; }; "Permissions" = { "filesystems" = "home"; }; };
     };
@@ -157,8 +157,8 @@ runTests {
   testEmptyBaseOverrides = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = {}; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = {}; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
       activeState = builtins.toJSON { };
       baseOverrides = builtins.toJSON { };
     };
@@ -168,8 +168,8 @@ runTests {
   testBaseOverridesWithEmptyState = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = {}; };
-      newState = builtins.toJSON { overrides = {}; };
+      oldState = builtins.toJSON { overrides.settings = {}; };
+      newState = builtins.toJSON { overrides.settings = {}; };
       activeState = builtins.toJSON { };
       baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; }; };
     };
@@ -179,8 +179,8 @@ runTests {
   testBaseOverridesWithNoChanges = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
       activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
       baseOverrides = builtins.toJSON { };
     };
@@ -190,8 +190,8 @@ runTests {
   testBaseOverridesWithMultipleApps = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = {}; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = {}; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
       activeState = builtins.toJSON { };
       baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; }; };
     };
@@ -201,8 +201,8 @@ runTests {
   testBaseOverridesWithMultipleAppsAndStateChanges = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = {}; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "network"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = {}; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "network"; }; }; }; };
       activeState = builtins.toJSON { };
       baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; }; };
     };
@@ -212,8 +212,8 @@ runTests {
   testBaseOverridesWithMultipleAppsAndNoChanges = {
     expr = runJqScript {
       appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
+      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
       activeState = builtins.toJSON { };
       baseOverrides = builtins.toJSON { };
     };

--- a/tests/state/overrides-test.nix
+++ b/tests/state/overrides-test.nix
@@ -2,10 +2,8 @@
 let
   inherit (pkgs) lib;
   inherit (lib) runTests;
-
   jqScriptPath = ../../modules/flatpak/state/overrides.jq;
-
-  runJqScript = { appId, oldState, newState, activeState }:
+  runJqScript = { appId, oldState, newState, activeState, baseOverrides ? "{}" }:
     let
       oldFile = pkgs.writeTextFile {
         name = "old-state.json";
@@ -19,6 +17,10 @@ let
         name = "active-state.json";
         text = activeState;
       };
+      baseFile = pkgs.writeTextFile {
+        name = "base-overrides.json";
+        text = baseOverrides;
+      };
       output = builtins.readFile (pkgs.runCommand "jq-result" {
         buildInputs = [ pkgs.jq ];
       } ''
@@ -27,12 +29,14 @@ let
           --argjson old_state "$(cat ${oldFile})" \
           --argjson new_state "$(cat ${newFile})" \
           --argjson active "$(cat ${activeFile})" \
+          --argjson base_overrides "$(cat ${baseFile})" \
           --from-file ${jqScriptPath} > $out
       '');
     in
-      builtins.toString output; # Preserve newline formatting for INI output
-
-in runTests {
+    builtins.toString output; # Preserve newline formatting for INI output
+in
+runTests {
+  # Original tests (should still pass)
   testNoChanges = {
     expr = runJqScript {
       appId = "com.example.app";
@@ -81,5 +85,138 @@ in runTests {
       activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
     };
     expected = "[Context]\nshared=network;ipc\n\n[Permissions]\ndevices=all\n\n";
+  };
+
+  # New tests for base overrides functionality
+  testBaseOverridesOnly = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = {}; };
+      newState = builtins.toJSON { overrides = {}; };
+      activeState = builtins.toJSON { };
+      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; "devices" = "dri"; }; };
+    };
+    expected = "[Context]\ndevices=dri\nshared=network\n\n";
+  };
+
+  testBaseOverridesWithStateChanges = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = {}; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; "Permissions" = { "filesystems" = "home"; }; }; }; };
+      activeState = builtins.toJSON { };
+      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; "devices" = "dri"; }; };
+    };
+    expected = "[Context]\ndevices=dri\nshared=ipc\n\n[Permissions]\nfilesystems=home\n\n";
+  };
+
+  testBaseOverridesWithArrayMerging = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = {}; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = [ "ipc" ]; }; }; }; };
+      activeState = builtins.toJSON { };
+      baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "network" ]; "devices" = [ "dri" ]; }; };
+    };
+    expected = "[Context]\ndevices=dri\nshared=network;ipc\n\n";
+  };
+
+  testBaseOverridesWithOldStateRemoval = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; }; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "x11"; }; }; }; };
+      activeState = builtins.toJSON { "Context" = { "shared" = [ "network" "ipc" ]; }; };
+      baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "network" ]; "devices" = [ "dri" ]; }; };
+    };
+    expected = "[Context]\ndevices=dri\nshared=x11\n\n";
+  };
+
+  testBaseOverridesOverriddenByState = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = {}; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "x11"; }; }; }; };
+      activeState = builtins.toJSON { };
+      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; "devices" = "dri"; }; };
+    };
+    expected = "[Context]\ndevices=dri\nshared=x11\n\n";
+  };
+
+  testComplexMergeScenario = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; "Permissions" = { "devices" = "all"; }; }; }; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = [ "ipc" "x11" ]; }; "Environment" = { "LANG" = "en_US.UTF-8"; }; }; }; };
+      activeState = builtins.toJSON { "Context" = { "shared" = [ "network" "pulseaudio" ]; }; "Permissions" = { "devices" = "all"; }; };
+      baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "pulseaudio" ]; "devices" = [ "dri" ]; }; "Permissions" = { "filesystems" = "home"; }; };
+    };
+    expected = "[Context]\ndevices=dri\nshared=pulseaudio;ipc;x11\n\n[Environment]\nLANG=en_US.UTF-8\n\n[Permissions]\nfilesystems=home\n\n";
+  };
+
+  testEmptyBaseOverrides = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = {}; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      activeState = builtins.toJSON { };
+      baseOverrides = builtins.toJSON { };
+    };
+    expected = "[Context]\nshared=network\n\n";
+  };
+
+  testBaseOverridesWithEmptyState = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = {}; };
+      newState = builtins.toJSON { overrides = {}; };
+      activeState = builtins.toJSON { };
+      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+    };
+    expected = "[Context]\nshared=network\n\n";
+  };
+
+  testBaseOverridesWithNoChanges = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+      baseOverrides = builtins.toJSON { };
+    };
+    expected = "[Context]\nshared=network\n\n";
+  };
+  
+  testBaseOverridesWithMultipleApps = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = {}; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
+      activeState = builtins.toJSON { };
+      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+    };
+    expected = "[Context]\nshared=network\n\n";
+  };
+
+  testBaseOverridesWithMultipleAppsAndStateChanges = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = {}; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "network"; }; }; }; };
+      activeState = builtins.toJSON { };
+      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+    };
+    expected = "[Context]\nshared=ipc\n\n";
+  };
+
+  testBaseOverridesWithMultipleAppsAndNoChanges = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
+      activeState = builtins.toJSON { };
+      baseOverrides = builtins.toJSON { };
+    };
+    expected = "[Context]\nshared=network\n\n";
   };
 }

--- a/tests/state/overrides-test.nix
+++ b/tests/state/overrides-test.nix
@@ -3,7 +3,7 @@ let
   inherit (pkgs) lib;
   inherit (lib) runTests;
   jqScriptPath = ../../modules/flatpak/state/overrides.jq;
-  runJqScript = { appId, oldState, newState, activeState, baseOverrides ? "{}" }:
+  runJqScript = { appId, oldState, newState, activeState, baseOverrides ? "{}", hasOverrideFile ? false, fileWasRemoved ? false }:
     let
       oldFile = pkgs.writeTextFile {
         name = "old-state.json";
@@ -21,6 +21,8 @@ let
         name = "base-overrides.json";
         text = baseOverrides;
       };
+      hasOverrideFileStr = if hasOverrideFile then "true" else "false";
+      fileWasRemovedStr = if fileWasRemoved then "true" else "false";
       output = builtins.readFile (pkgs.runCommand "jq-result" {
         buildInputs = [ pkgs.jq ];
       } ''
@@ -30,6 +32,8 @@ let
           --argjson new_state "$(cat ${newFile})" \
           --argjson active "$(cat ${activeFile})" \
           --argjson base_overrides "$(cat ${baseFile})" \
+          --argjson has_override_file ${hasOverrideFileStr} \
+          --argjson file_was_removed ${fileWasRemovedStr} \
           --from-file ${jqScriptPath} > $out
       '');
     in
@@ -218,5 +222,215 @@ runTests {
       baseOverrides = builtins.toJSON { };
     };
     expected = "[Context]\nshared=network\n\n";
+  };
+
+  # Override file is authoritative (fixes append bug)
+  testOverrideFileAuthoritative = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides.settings = {}; };
+      newState = builtins.toJSON { overrides.settings = {}; };
+      activeState = builtins.toJSON { "Context" = { "shared" = [ "old" "values" ]; }; };
+      baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "new" "content" ]; }; };
+      hasOverrideFile = true;
+    };
+    expected = "[Context]\nshared=new;content\n\n";
+  };
+
+  # Override file replaces content completely
+  testOverrideFileReplacesContent = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides.settings = {}; };
+      newState = builtins.toJSON { overrides.settings = {}; };
+      activeState = builtins.toJSON { "Context" = { "sockets" = [ "wayland" "!x11" ]; }; };
+      baseOverrides = builtins.toJSON { "Context" = { "sockets" = [ "wayland" "x11" ]; }; };
+      hasOverrideFile = true;
+    };
+    expected = "[Context]\nsockets=wayland;x11\n\n";
+  };
+
+  # Override file with nix settings merged
+  testOverrideFileWithSettings = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides.settings = {}; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Environment" = { "LANG" = "en_US.UTF-8"; }; }; }; };
+      activeState = builtins.toJSON { "Context" = { "shared" = [ "old" ]; }; };
+      baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "network" ]; }; };
+      hasOverrideFile = true;
+    };
+    expected = "[Context]\nshared=network\n\n[Environment]\nLANG=en_US.UTF-8\n\n";
+  };
+
+  # Without override file, manual changes are preserved
+  testNoOverrideFilePreservesManualChanges = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; }; }; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; }; }; };
+      activeState = builtins.toJSON { "Context" = { "shared" = [ "network" "manual-add" ]; }; };
+      baseOverrides = builtins.toJSON { };
+      hasOverrideFile = false;
+    };
+    # Order: (active - old) comes before new in the formula
+    expected = "[Context]\nshared=manual-add;network\n\n";
+  };
+
+  # When file is removed but settings remain, file-based content should be cleared
+  testFileRemovedSettingsRemain = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      # Old state had the app configured via files
+      oldState = builtins.toJSON {
+        overrides = {
+          settings = {};
+          files = [ "/path/to/com.example.app" ];
+        };
+      };
+      # New state has settings for the app but no file
+      newState = builtins.toJSON {
+        overrides.settings = {
+          "com.example.app" = {
+            "Context" = { "shared" = [ "network" ]; };
+          };
+        };
+      };
+      # Active state contains values from the old file
+      activeState = builtins.toJSON {
+        "Context" = { "shared" = [ "old-file-value" "another-old" ]; };
+      };
+      baseOverrides = builtins.toJSON { };
+      hasOverrideFile = false;
+      fileWasRemoved = true;
+    };
+    # File content should be cleared, only new settings remain
+    expected = "[Context]\nshared=network\n\n";
+  };
+
+  # File removed with no settings. Authoritative merge clears everything
+  testFileRemovedNoSettingsAuthoritative = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON {
+        overrides = {
+          settings = {};
+          files = [ "/path/to/com.example.app" ];
+        };
+      };
+      newState = builtins.toJSON { overrides.settings = {}; };
+      # Active state contains old file values that should be cleared
+      activeState = builtins.toJSON {
+        "Context" = { "shared" = [ "old-file-value" ]; };
+      };
+      baseOverrides = builtins.toJSON { };
+      hasOverrideFile = false;
+      fileWasRemoved = true;
+    };
+    # Everything should be cleared (empty output)
+    expected = "";
+  };
+
+  # File removed but new settings added for same entry
+  testFileRemovedNewSettingsAdded = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON {
+        overrides = {
+          settings = {};
+          files = [ "/path/to/com.example.app" ];
+        };
+      };
+      newState = builtins.toJSON {
+        overrides.settings = {
+          "com.example.app" = {
+            "Context" = { "shared" = [ "ipc" ]; };
+            "Environment" = { "LANG" = "en_US.UTF-8"; };
+          };
+        };
+      };
+      activeState = builtins.toJSON {
+        "Context" = { "shared" = [ "network" "pulseaudio" ]; "devices" = [ "dri" ]; };
+      };
+      baseOverrides = builtins.toJSON { };
+      hasOverrideFile = false;
+      fileWasRemoved = true;
+    };
+    # Old file content cleared, only new settings applied
+    expected = "[Context]\nshared=ipc\n\n[Environment]\nLANG=en_US.UTF-8\n\n";
+  };
+
+  # File not removed from `files`. Manual changes should still be preserved
+  testFileNotRemovedPreservesManual = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON {
+        overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; }; };
+      };
+      newState = builtins.toJSON {
+        overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; }; };
+      };
+      activeState = builtins.toJSON {
+        "Context" = { "shared" = [ "network" "manual-change" ]; };
+      };
+      baseOverrides = builtins.toJSON { };
+      hasOverrideFile = false;
+      fileWasRemoved = false;
+    };
+    # Manual changes preserved because file was not removed
+    expected = "[Context]\nshared=manual-change;network\n\n";
+  };
+
+  # Backwards compatibility tests for legacy format (overrides without .settings)
+  testLegacyFormatBasic = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      # Legacy format: overrides contains app configs (no .settings attribute)
+      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+    };
+    expected = "[Context]\nshared=network\n\n";
+  };
+
+  testLegacyFormatNewOverrideAdded = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = { "com.example.app" = {}; }; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; }; };
+      activeState = builtins.toJSON { };
+    };
+    expected = "[Context]\nshared=ipc\n\n";
+  };
+
+  testLegacyFormatOverrideRemoved = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = {}; }; };
+      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+    };
+    expected = "";
+  };
+
+  testLegacyFormatOverrideUpdated = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "x11"; }; }; }; };
+      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+    };
+    expected = "[Context]\nshared=x11\n\n";
+  };
+
+  # Mixed format: old state in legacy format, new state in new format.
+  testMixedFormatUpgrade = {
+    expr = runJqScript {
+      appId = "com.example.app";
+      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
+      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; }; };
+      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+    };
+    expected = "[Context]\nshared=ipc\n\n";
   };
 }

--- a/tests/state/overrides-test.nix
+++ b/tests/state/overrides-test.nix
@@ -775,4 +775,40 @@ in
       expr = lib.strings.hasInfix ''$old.overrides[$app_id]'' installWithReplaceModeAndPrune.mkOverridesCmd;
       expected = true;
     };
+
+    testNoMetaKeyLeakWhenOldStateV2LacksSettingsKey = {
+      expr = builtins.readFile (pkgs.runCommand "app-ids-no-meta-keys" {
+          buildInputs = [pkgs.jq];
+        } ''
+          NEW_STATE='${builtins.toJSON {
+            version = 2;
+            overrides = {
+              settings = {};
+              files = ["/path/org.gnome.gedit"];
+              pruneUnmanagedOverrides = false;
+              writeMode = "merge";
+              _fileSettings."org.gnome.gedit" = {Context.sockets = "wayland";};
+            };
+          }}'
+          # Old state is v2-format but missing the `settings` key — the bug trigger.
+          OLD_STATE='${builtins.toJSON {
+            version = 2;
+            overrides = {
+              files = ["/path/org.gnome.gedit"];
+              pruneUnmanagedOverrides = false;
+              writeMode = "merge";
+              _fileSettings."org.gnome.gedit" = {Context.sockets = "wayland";};
+            };
+          }}'
+          APP_IDS=$(${pkgs.jq}/bin/jq -r -n \
+            --argjson old "$OLD_STATE" \
+            --argjson new "$NEW_STATE" \
+            '[ (if ($new.version // 1) >= 2 then ($new.overrides.settings // {}) else ($new.overrides // {}) end | keys[]),
+               (($new.overrides._fileSettings // {}) | keys[]),
+               (if ($old.version // 1) >= 2 then ($old.overrides.settings // {}) else ($old.overrides // {}) end | keys[]),
+               ($old.overrides.files // [] | map(split("/") | last) | .[]) ] | unique[]')
+          echo -n "$APP_IDS" > $out
+        '');
+      expected = "org.gnome.gedit";
+    };
   }

--- a/tests/state/overrides-test.nix
+++ b/tests/state/overrides-test.nix
@@ -1,622 +1,778 @@
-{ pkgs ? import <nixpkgs> { } }:
-let
+{pkgs ? import <nixpkgs> {}}: let
   inherit (pkgs) lib;
   inherit (lib) runTests;
   jqScriptPath = ../../modules/flatpak/state/overrides.jq;
 
   # Runs the orphan-deletion loop against a temporary overrides directory.
   # Returns "exists" if `appId` is still present afterwards, "deleted" if not.
-  runDeleteOrphanedTest = { appId, oldStateJson, newStateJson, overrideFilesJson ? "{}" }:
+  runDeleteOrphanedTest = {
+    appId,
+    oldStateJson,
+    newStateJson,
+    overrideFilesJson ? "{}",
+  }:
     builtins.readFile (pkgs.runCommand "delete-orphaned-${appId}" {
-      buildInputs = [ pkgs.jq pkgs.coreutils ];
-    } ''
-      OVERRIDES_DIR=$(mktemp -d)
-      touch "$OVERRIDES_DIR/${appId}"
+        buildInputs = [pkgs.jq pkgs.coreutils];
+      } ''
+        OVERRIDES_DIR=$(mktemp -d)
+        touch "$OVERRIDES_DIR/${appId}"
 
-      OLD_STATE='${oldStateJson}'
-      NEW_STATE='${newStateJson}'
+        OLD_STATE='${oldStateJson}'
+        NEW_STATE='${newStateJson}'
 
-      for OVERRIDE_FILE in "$OVERRIDES_DIR"/*; do
-        [[ -f "$OVERRIDE_FILE" ]] || continue
-        APP_ID=$(${pkgs.coreutils}/bin/basename "$OVERRIDE_FILE")
+        for OVERRIDE_FILE in "$OVERRIDES_DIR"/*; do
+          [[ -f "$OVERRIDE_FILE" ]] || continue
+          APP_ID=$(${pkgs.coreutils}/bin/basename "$OVERRIDE_FILE")
 
-        OVERRIDES_WAS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
-          --arg app_id "$APP_ID" \
-          --argjson old "$OLD_STATE" \
-          '(($old.overrides.settings[$app_id] // $old.overrides[$app_id]) != null) or
-           ($old.overrides.files // [] | map(split("/") | last) | index($app_id) != null)')
+          OVERRIDES_WAS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
+            --arg app_id "$APP_ID" \
+            --argjson old "$OLD_STATE" \
+            '(($old.overrides.settings[$app_id] // $old.overrides[$app_id]) != null) or
+             ($old.overrides.files // [] | map(split("/") | last) | index($app_id) != null)')
 
-        OVERRIDES_IS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
-          --arg app_id "$APP_ID" \
-          --argjson new "$NEW_STATE" \
-          --argjson override_files '${overrideFilesJson}' \
-          '(($new.overrides.settings[$app_id] // $new.overrides[$app_id]) != null) or
-           ($override_files[$app_id] != null)')
+          OVERRIDES_IS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
+            --arg app_id "$APP_ID" \
+            --argjson new "$NEW_STATE" \
+            '(($new.overrides.settings[$app_id] // $new.overrides[$app_id]) != null) or
+             (($new.overrides._fileSettings[$app_id] // null) != null)')
 
-        if [[ "$OVERRIDES_WAS_MANAGED" == "true" && "$OVERRIDES_IS_MANAGED" == "false" ]]; then
-          ${pkgs.coreutils}/bin/rm -f "$OVERRIDE_FILE"
+          if [[ "$OVERRIDES_WAS_MANAGED" == "true" && "$OVERRIDES_IS_MANAGED" == "false" ]]; then
+            ${pkgs.coreutils}/bin/rm -f "$OVERRIDE_FILE"
+          fi
+        done
+
+        if [[ -f "$OVERRIDES_DIR/${appId}" ]]; then
+          echo -n "exists" > $out
+        else
+          echo -n "deleted" > $out
         fi
-      done
+      '');
 
-      if [[ -f "$OVERRIDES_DIR/${appId}" ]]; then
-        echo -n "exists" > $out
-      else
-        echo -n "deleted" > $out
-      fi
-    '');
+  # Fixture override file paths (store-path-safe: toString of a Nix path literal)
+  comOtherAppPath = toString ../fixtures/overrides/com.other.app;
 
   # install.nix instances for structural tests
   installation = "user";
   baseConfig = {
-    update = { onActivation = false; auto = { enable = false; }; };
-    remotes = [{ name = "some-remote"; location = "https://some.remote.tld/repo/test-remote.flatpakrepo"; }];
-    packages = [{ appId = "SomeAppId"; origin = "some-remote"; bundle = null; sha256 = null; }];
+    update = {
+      onActivation = false;
+      auto = {enable = false;};
+    };
+    remotes = [
+      {
+        name = "some-remote";
+        location = "https://some.remote.tld/repo/test-remote.flatpakrepo";
+      }
+    ];
+    packages = [
+      {
+        appId = "SomeAppId";
+        origin = "some-remote";
+        bundle = null;
+        sha256 = null;
+      }
+    ];
     uninstallUnmanaged = false;
     uninstallUnused = false;
   };
-  installWithDeleteOrphanedFiles = import ../../modules/flatpak/install.nix {
-    cfg = baseConfig // {
-      overrides = {
-        settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; };
-        files = [ "/path/to/com.other.app" ];
-        deleteOrphanedFiles = true;
+  installWithPruneUnmanagedOverrides = import ../../modules/flatpak/install.nix {
+    cfg =
+      baseConfig
+      // {
+        overrides = {
+          settings = {"com.example.app" = {"Context" = {"shared" = "network";};};};
+          files = [(toString ../fixtures/overrides/com.other.app)];
+          pruneUnmanagedOverrides = true;
+        };
       };
-    };
     inherit pkgs lib installation;
     executionContext = "service-start";
   };
-  installWithoutDeleteOrphanedFiles = import ../../modules/flatpak/install.nix {
-    cfg = baseConfig // {
-      overrides = {
-        settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; };
+  installWithoutPruneUnmanagedOverrides = import ../../modules/flatpak/install.nix {
+    cfg =
+      baseConfig
+      // {
+        overrides = {
+          settings = {"com.example.app" = {"Context" = {"shared" = "network";};};};
+        };
       };
-    };
     inherit pkgs lib installation;
     executionContext = "service-start";
   };
 
-  runJqScript = { appId, oldState, newState, activeState, baseOverrides ? "{}", hasOverrideFile ? false, fileWasRemoved ? false }:
-    let
-      oldFile = pkgs.writeTextFile {
-        name = "old-state.json";
-        text = oldState;
+  installWithReplaceMode = import ../../modules/flatpak/install.nix {
+    cfg =
+      baseConfig
+      // {
+        overrides = {
+          writeMode = "replace";
+          settings = {"com.example.app" = {"Context" = {"shared" = "network";};};};
+          files = [comOtherAppPath];
+        };
       };
-      newFile = pkgs.writeTextFile {
-        name = "new-state.json";
-        text = newState;
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
+
+  installWithReplaceModeAndPrune = import ../../modules/flatpak/install.nix {
+    cfg =
+      baseConfig
+      // {
+        overrides = {
+          writeMode = "replace";
+          pruneUnmanagedOverrides = true;
+          settings = {"com.example.app" = {"Context" = {"shared" = "network";};};};
+        };
       };
-      activeFile = pkgs.writeTextFile {
-        name = "active-state.json";
-        text = activeState;
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
+
+  installWithExplicitMergeMode = import ../../modules/flatpak/install.nix {
+    cfg =
+      baseConfig
+      // {
+        overrides = {
+          writeMode = "merge";
+          settings = {"com.example.app" = {"Context" = {"shared" = "network";};};};
+        };
       };
-      baseFile = pkgs.writeTextFile {
-        name = "base-overrides.json";
-        text = baseOverrides;
-      };
-      hasOverrideFileStr = if hasOverrideFile then "true" else "false";
-      fileWasRemovedStr = if fileWasRemoved then "true" else "false";
-      output = builtins.readFile (pkgs.runCommand "jq-result" {
-        buildInputs = [ pkgs.jq ];
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
+
+  runJqScript = {
+    appId,
+    newState,
+    activeState,
+    oldState ? "{}",
+  }: let
+    newFile = pkgs.writeTextFile {
+      name = "new-state.json";
+      text = newState;
+    };
+    activeFile = pkgs.writeTextFile {
+      name = "active-state.json";
+      text = activeState;
+    };
+    oldFile = pkgs.writeTextFile {
+      name = "old-state.json";
+      text = oldState;
+    };
+    output = builtins.readFile (pkgs.runCommand "jq-result" {
+        buildInputs = [pkgs.jq];
       } ''
         ${pkgs.jq}/bin/jq -r -n \
           --arg app_id "${appId}" \
-          --argjson old_state "$(cat ${oldFile})" \
           --argjson new_state "$(cat ${newFile})" \
           --argjson active "$(cat ${activeFile})" \
-          --argjson base_overrides "$(cat ${baseFile})" \
-          --argjson has_override_file ${hasOverrideFileStr} \
-          --argjson file_was_removed ${fileWasRemovedStr} \
+          --argjson old_state "$(cat ${oldFile})" \
           --from-file ${jqScriptPath} > $out
       '');
-    in
+  in
     builtins.toString output; # Preserve newline formatting for INI output
 in
-runTests {
-  testNoChanges = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+  runTests {
+    testNoChanges = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides.settings = {"com.example.app" = {"Context" = {"shared" = "network";};};};};
+        activeState = builtins.toJSON {"Context" = {"shared" = "network";};};
+      };
+      expected = "[Context]\nshared=network\n\n";
     };
-    expected = "[Context]\nshared=network\n\n";
-  };
 
-  testNewOverrideAdded = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = {}; }; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      activeState = builtins.toJSON { };
+    testNewOverrideAdded = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides.settings = {"com.example.app" = {"Context" = {"shared" = "network";};};};};
+        activeState = builtins.toJSON {};
+      };
+      expected = "[Context]\nshared=network\n\n";
     };
-    expected = "[Context]\nshared=network\n\n";
-  };
 
-  testOverrideRemoved = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = {}; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+    testOverrideRemoved = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides.settings = {"com.example.app" = {};};};
+        activeState = builtins.toJSON {"Context" = {"shared" = "network";};};
+      };
+      # Active value preserved: settings no longer claims this key
+      expected = "[Context]\nshared=network\n\n";
     };
-    expected = "";
-  };
 
-  testOverrideUpdated = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+    testOverrideUpdated = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides.settings = {"com.example.app" = {"Context" = {"shared" = "ipc";};};};};
+        activeState = builtins.toJSON {"Context" = {"shared" = "network";};};
+      };
+      expected = "[Context]\nshared=ipc\n\n";
     };
-    expected = "[Context]\nshared=ipc\n\n";
-  };
 
-  testMultipleSections = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network;ipc"; }; "Permissions" = { "devices" = "all"; }; }; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
+    testMultipleSections = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides.settings = {
+            "com.example.app" = {
+              "Context" = {"shared" = "network;ipc";};
+              "Permissions" = {"devices" = "all";};
+            };
+          };
+        };
+        activeState = builtins.toJSON {"Context" = {"shared" = "network";};};
+      };
+      expected = "[Context]\nshared=network;ipc\n\n[Permissions]\ndevices=all\n\n";
     };
-    expected = "[Context]\nshared=network;ipc\n\n[Permissions]\ndevices=all\n\n";
-  };
 
-  # New tests for base overrides functionality
-  testBaseOverridesOnly = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = {}; };
-      newState = builtins.toJSON { overrides.settings = {}; };
-      activeState = builtins.toJSON { };
-      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; "devices" = "dri"; }; };
+    testFileSettingsOnly = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides._fileSettings."com.example.app" = {
+            "Context" = {
+              "shared" = "network";
+              "devices" = "dri";
+            };
+          };
+        };
+        activeState = builtins.toJSON {};
+      };
+      expected = "[Context]\ndevices=dri\nshared=network\n\n";
     };
-    expected = "[Context]\ndevices=dri\nshared=network\n\n";
-  };
 
-  testBaseOverridesWithStateChanges = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = {}; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; "Permissions" = { "filesystems" = "home"; }; }; }; };
-      activeState = builtins.toJSON { };
-      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; "devices" = "dri"; }; };
+    testSettingsWinsOverFileSettings = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides = {
+            settings."com.example.app" = {
+              "Context" = {"shared" = "ipc";};
+              "Permissions" = {"filesystems" = "home";};
+            };
+            _fileSettings."com.example.app" = {
+              "Context" = {
+                "shared" = "network";
+                "devices" = "dri";
+              };
+            };
+          };
+        };
+        activeState = builtins.toJSON {};
+      };
+      expected = "[Context]\ndevices=dri\nshared=ipc\n\n[Permissions]\nfilesystems=home\n\n";
     };
-    expected = "[Context]\ndevices=dri\nshared=ipc\n\n[Permissions]\nfilesystems=home\n\n";
-  };
 
-  testBaseOverridesWithArrayMerging = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = {}; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "ipc" ]; }; }; }; };
-      activeState = builtins.toJSON { };
-      baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "network" ]; "devices" = [ "dri" ]; }; };
+    testSettingsWinsOverFileSettingsArrays = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides = {
+            settings."com.example.app" = {"Context" = {"shared" = ["ipc"];};};
+            _fileSettings."com.example.app" = {
+              "Context" = {
+                "shared" = ["network"];
+                "devices" = ["dri"];
+              };
+            };
+          };
+        };
+        activeState = builtins.toJSON {};
+      };
+      expected = "[Context]\ndevices=dri\nshared=ipc\n\n";
     };
-    expected = "[Context]\ndevices=dri\nshared=network;ipc\n\n";
-  };
 
-  testBaseOverridesWithOldStateRemoval = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; }; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "x11"; }; }; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = [ "network" "ipc" ]; }; };
-      baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "network" ]; "devices" = [ "dri" ]; }; };
+    testSettingsRemovedFileSettingsFallback = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides = {
+            settings."com.example.app" = {"Context" = {"shared" = "x11";};};
+            _fileSettings."com.example.app" = {
+              "Context" = {
+                "shared" = ["network"];
+                "devices" = ["dri"];
+              };
+            };
+          };
+        };
+        activeState = builtins.toJSON {"Context" = {"shared" = ["network" "ipc"];};};
+      };
+      expected = "[Context]\ndevices=dri\nshared=x11\n\n";
     };
-    expected = "[Context]\ndevices=dri\nshared=x11\n\n";
-  };
 
-  testBaseOverridesOverriddenByState = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = {}; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "x11"; }; }; }; };
-      activeState = builtins.toJSON { };
-      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; "devices" = "dri"; }; };
-    };
-    expected = "[Context]\ndevices=dri\nshared=x11\n\n";
-  };
-
-  testComplexMergeScenario = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; "Permissions" = { "devices" = "all"; }; }; }; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "ipc" "x11" ]; }; "Environment" = { "LANG" = "en_US.UTF-8"; }; }; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = [ "network" "pulseaudio" ]; }; "Permissions" = { "devices" = "all"; }; };
-      baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "pulseaudio" ]; "devices" = [ "dri" ]; }; "Permissions" = { "filesystems" = "home"; }; };
-    };
-    expected = "[Context]\ndevices=dri\nshared=pulseaudio;ipc;x11\n\n[Environment]\nLANG=en_US.UTF-8\n\n[Permissions]\nfilesystems=home\n\n";
-  };
-
-  testEmptyBaseOverrides = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = {}; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      activeState = builtins.toJSON { };
-      baseOverrides = builtins.toJSON { };
-    };
-    expected = "[Context]\nshared=network\n\n";
-  };
-
-  testBaseOverridesWithEmptyState = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = {}; };
-      newState = builtins.toJSON { overrides.settings = {}; };
-      activeState = builtins.toJSON { };
-      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; }; };
-    };
-    expected = "[Context]\nshared=network\n\n";
-  };
-
-  testBaseOverridesWithNoChanges = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
-      baseOverrides = builtins.toJSON { };
-    };
-    expected = "[Context]\nshared=network\n\n";
-  };
-  
-  testBaseOverridesWithMultipleApps = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = {}; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
-      activeState = builtins.toJSON { };
-      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; }; };
-    };
-    expected = "[Context]\nshared=network\n\n";
-  };
-
-  testBaseOverridesWithMultipleAppsAndStateChanges = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = {}; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "network"; }; }; }; };
-      activeState = builtins.toJSON { };
-      baseOverrides = builtins.toJSON { "Context" = { "shared" = "network"; }; };
-    };
-    expected = "[Context]\nshared=ipc\n\n";
-  };
-
-  testBaseOverridesWithMultipleAppsAndNoChanges = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; "com.example.otherapp" = { "Context" = { "shared" = "ipc"; }; }; }; };
-      activeState = builtins.toJSON { };
-      baseOverrides = builtins.toJSON { };
-    };
-    expected = "[Context]\nshared=network\n\n";
-  };
-
-  # Override file is authoritative (fixes append bug)
-  testOverrideFileAuthoritative = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = {}; };
-      newState = builtins.toJSON { overrides.settings = {}; };
-      activeState = builtins.toJSON { "Context" = { "shared" = [ "old" "values" ]; }; };
-      baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "new" "content" ]; }; };
-      hasOverrideFile = true;
-    };
-    expected = "[Context]\nshared=new;content\n\n";
-  };
-
-  # Override file replaces content completely
-  testOverrideFileReplacesContent = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = {}; };
-      newState = builtins.toJSON { overrides.settings = {}; };
-      activeState = builtins.toJSON { "Context" = { "sockets" = [ "wayland" "!x11" ]; }; };
-      baseOverrides = builtins.toJSON { "Context" = { "sockets" = [ "wayland" "x11" ]; }; };
-      hasOverrideFile = true;
-    };
-    expected = "[Context]\nsockets=wayland;x11\n\n";
-  };
-
-  # Override file with nix settings merged
-  testOverrideFileWithSettings = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = {}; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Environment" = { "LANG" = "en_US.UTF-8"; }; }; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = [ "old" ]; }; };
-      baseOverrides = builtins.toJSON { "Context" = { "shared" = [ "network" ]; }; };
-      hasOverrideFile = true;
-    };
-    expected = "[Context]\nshared=network\n\n[Environment]\nLANG=en_US.UTF-8\n\n";
-  };
-
-  # Without override file, manual changes are preserved
-  testNoOverrideFilePreservesManualChanges = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; }; }; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; }; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = [ "network" "manual-add" ]; }; };
-      baseOverrides = builtins.toJSON { };
-      hasOverrideFile = false;
-    };
-    # Order: (active - old) comes before new in the formula
-    expected = "[Context]\nshared=manual-add;network\n\n";
-  };
-
-  # When file is removed but settings remain, file-based content should be cleared
-  testFileRemovedSettingsRemain = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      # Old state had the app configured via files
-      oldState = builtins.toJSON {
-        overrides = {
-          settings = {};
-          files = [ "/path/to/com.example.app" ];
+    testComplexMergeScenario = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides = {
+            settings."com.example.app" = {
+              "Context" = {"shared" = ["ipc" "x11"];};
+              "Environment" = {"LANG" = "en_US.UTF-8";};
+            };
+            _fileSettings."com.example.app" = {
+              "Context" = {
+                "shared" = ["pulseaudio"];
+                "devices" = ["dri"];
+              };
+              "Permissions" = {"filesystems" = "home";};
+            };
+          };
+        };
+        activeState = builtins.toJSON {
+          "Context" = {"shared" = ["network" "pulseaudio"];};
+          "Permissions" = {"devices" = "all";};
         };
       };
-      # New state has settings for the app but no file
-      newState = builtins.toJSON {
-        overrides.settings = {
-          "com.example.app" = {
-            "Context" = { "shared" = [ "network" ]; };
+      expected = "[Context]\ndevices=dri\nshared=ipc;x11\n\n[Environment]\nLANG=en_US.UTF-8\n\n[Permissions]\ndevices=all\nfilesystems=home\n\n";
+    };
+
+    testEmptyFileSettings = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides = {
+            settings."com.example.app" = {"Context" = {"shared" = "network";};};
+            _fileSettings = {};
+          };
+        };
+        activeState = builtins.toJSON {};
+      };
+      expected = "[Context]\nshared=network\n\n";
+    };
+
+    testFileSettingsWithNoChanges = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides = {
+            settings."com.example.app" = {"Context" = {"shared" = "network";};};
+            _fileSettings = {};
+          };
+        };
+        activeState = builtins.toJSON {"Context" = {"shared" = "network";};};
+      };
+      expected = "[Context]\nshared=network\n\n";
+    };
+
+    testFileSettingsWithMultipleApps = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides.settings = {
+            "com.example.app" = {"Context" = {"shared" = "network";};};
+            "com.example.otherapp" = {"Context" = {"shared" = "ipc";};};
+          };
+        };
+        activeState = builtins.toJSON {};
+      };
+      expected = "[Context]\nshared=network\n\n";
+    };
+
+    testFileSettingsAuthoritativeOverActive = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides._fileSettings."com.example.app" = {"Context" = {"shared" = ["new" "content"];};};
+        };
+        activeState = builtins.toJSON {"Context" = {"shared" = ["old" "values"];};};
+      };
+      expected = "[Context]\nshared=new;content\n\n";
+    };
+
+    # _fileSettings wins over active for same key; active extras for other keys preserved
+    testFileSettingsWithActiveExtras = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides._fileSettings."com.example.app" = {"Context" = {"sockets" = ["wayland" "x11"];};};
+        };
+        activeState = builtins.toJSON {"Context" = {"sockets" = ["wayland" "!x11"];};};
+      };
+      expected = "[Context]\nsockets=wayland;x11\n\n";
+    };
+
+    # settings wins; _fileSettings used for keys not in settings; active preserved for the rest
+    testFileSettingsWithSettingsMerge = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides = {
+            settings."com.example.app" = {"Environment" = {"LANG" = "en_US.UTF-8";};};
+            _fileSettings."com.example.app" = {"Context" = {"shared" = ["network"];};};
+          };
+        };
+        activeState = builtins.toJSON {"Context" = {"shared" = ["old"];};};
+      };
+      expected = "[Context]\nshared=network\n\n[Environment]\nLANG=en_US.UTF-8\n\n";
+    };
+
+    testSettingsRemovedPreservesActive = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        # settings no longer declares "shared"; active retains a manual edit
+        newState = builtins.toJSON {overrides.settings = {"com.example.app" = {};};};
+        activeState = builtins.toJSON {"Context" = {"shared" = ["network" "manual-add"];};};
+      };
+      expected = "[Context]\nshared=network;manual-add\n\n";
+    };
+
+    testSettingsPresentWinsOverActive = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides.settings = {"com.example.app" = {"Context" = {"shared" = ["network"];};};};};
+        activeState = builtins.toJSON {"Context" = {"shared" = ["network" "manual-add"];};};
+      };
+      expected = "[Context]\nshared=network\n\n";
+    };
+
+    testFileRemovedUserEditPreserved = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides.settings = {};};
+        # old_state has no _fileSettings for this app → key was a direct user edit
+        oldState = builtins.toJSON {overrides._fileSettings = {};};
+        activeState = builtins.toJSON {
+          "Context" = {"shared" = ["user-edit-value"];};
+        };
+      };
+      # User-typed key preserved since it was not in old _fileSettings
+      expected = "[Context]\nshared=user-edit-value\n\n";
+    };
+
+    testFileRemovedStaleFileSettingsRetracted = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides.settings = {};};
+        oldState = builtins.toJSON {
+          overrides._fileSettings."com.example.app" = {
+            "Context" = {"shared" = ["old-file-value"];};
+          };
+        };
+        activeState = builtins.toJSON {
+          "Context" = {"shared" = ["old-file-value"];};
+        };
+      };
+      expected = "";
+    };
+
+    testFileRemovedPartialRetraction = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides.settings = {};};
+        oldState = builtins.toJSON {
+          overrides._fileSettings."com.example.app" = {
+            "Context" = {"shared" = ["old-file-value"];};
+          };
+        };
+        activeState = builtins.toJSON {
+          "Context" = {
+            "shared" = ["old-file-value"]; # from _fileSettings → retracted
+            "devices" = "dri"; # direct user edit → preserved
           };
         };
       };
-      # Active state contains values from the old file
-      activeState = builtins.toJSON {
-        "Context" = { "shared" = [ "old-file-value" "another-old" ]; };
-      };
-      baseOverrides = builtins.toJSON { };
-      hasOverrideFile = false;
-      fileWasRemoved = true;
+      expected = "[Context]\ndevices=dri\n\n";
     };
-    # File content should be cleared, only new settings remain
-    expected = "[Context]\nshared=network\n\n";
-  };
 
-  # File removed with no settings. Authoritative merge clears everything
-  testFileRemovedNoSettingsAuthoritative = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON {
-        overrides = {
-          settings = {};
-          files = [ "/path/to/com.example.app" ];
+    testFileRemovedSettingsRemain = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides.settings."com.example.app" = {
+            "Context" = {"shared" = ["network"];};
+          };
+        };
+        activeState = builtins.toJSON {
+          "Context" = {"shared" = ["old-file-value" "another-old"];};
         };
       };
-      newState = builtins.toJSON { overrides.settings = {}; };
-      # Active state contains old file values that should be cleared
-      activeState = builtins.toJSON {
-        "Context" = { "shared" = [ "old-file-value" ]; };
-      };
-      baseOverrides = builtins.toJSON { };
-      hasOverrideFile = false;
-      fileWasRemoved = true;
+      expected = "[Context]\nshared=network\n\n";
     };
-    # Everything should be cleared (empty output)
-    expected = "";
-  };
 
-  # File removed but new settings added for same entry
-  testFileRemovedNewSettingsAdded = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON {
-        overrides = {
-          settings = {};
-          files = [ "/path/to/com.example.app" ];
+    testFileRemovedNewSettingsAdded = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {
+          overrides.settings."com.example.app" = {
+            "Context" = {"shared" = ["ipc"];};
+            "Environment" = {"LANG" = "en_US.UTF-8";};
+          };
         };
-      };
-      newState = builtins.toJSON {
-        overrides.settings = {
-          "com.example.app" = {
-            "Context" = { "shared" = [ "ipc" ]; };
-            "Environment" = { "LANG" = "en_US.UTF-8"; };
+        activeState = builtins.toJSON {
+          "Context" = {
+            "shared" = ["network" "pulseaudio"];
+            "devices" = ["dri"];
           };
         };
       };
-      activeState = builtins.toJSON {
-        "Context" = { "shared" = [ "network" "pulseaudio" ]; "devices" = [ "dri" ]; };
-      };
-      baseOverrides = builtins.toJSON { };
-      hasOverrideFile = false;
-      fileWasRemoved = true;
+      expected = "[Context]\ndevices=dri\nshared=ipc\n\n[Environment]\nLANG=en_US.UTF-8\n\n";
     };
-    # Old file content cleared, only new settings applied
-    expected = "[Context]\nshared=ipc\n\n[Environment]\nLANG=en_US.UTF-8\n\n";
-  };
 
-  # File not removed from `files`. Manual changes should still be preserved
-  testFileNotRemovedPreservesManual = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON {
-        overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; }; };
+    testLegacyFormatBasic = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides = {"com.example.app" = {"Context" = {"shared" = "network";};};};};
+        activeState = builtins.toJSON {"Context" = {"shared" = "network";};};
       };
-      newState = builtins.toJSON {
-        overrides.settings = { "com.example.app" = { "Context" = { "shared" = [ "network" ]; }; }; };
-      };
-      activeState = builtins.toJSON {
-        "Context" = { "shared" = [ "network" "manual-change" ]; };
-      };
-      baseOverrides = builtins.toJSON { };
-      hasOverrideFile = false;
-      fileWasRemoved = false;
+      expected = "[Context]\nshared=network\n\n";
     };
-    # Manual changes preserved because file was not removed
-    expected = "[Context]\nshared=manual-change;network\n\n";
-  };
 
-  # Backwards compatibility tests for legacy format (overrides without .settings)
-  testLegacyFormatBasic = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      # Legacy format: overrides contains app configs (no .settings attribute)
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
-    };
-    expected = "[Context]\nshared=network\n\n";
-  };
-
-  testLegacyFormatNewOverrideAdded = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = {}; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; }; };
-      activeState = builtins.toJSON { };
-    };
-    expected = "[Context]\nshared=ipc\n\n";
-  };
-
-  testLegacyFormatOverrideRemoved = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = {}; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
-    };
-    expected = "";
-  };
-
-  testLegacyFormatOverrideUpdated = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "x11"; }; }; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
-    };
-    expected = "[Context]\nshared=x11\n\n";
-  };
-
-  # Mixed format: old state in legacy format, new state in new format.
-  testMixedFormatUpgrade = {
-    expr = runJqScript {
-      appId = "com.example.app";
-      oldState = builtins.toJSON { overrides = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; }; };
-      newState = builtins.toJSON { overrides.settings = { "com.example.app" = { "Context" = { "shared" = "ipc"; }; }; }; };
-      activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
-    };
-    expected = "[Context]\nshared=ipc\n\n";
-  };
-
-
-  # deleteOrphanedFiles=true must generate a script containing OVERRIDES_WAS_MANAGED
-  # (the old-state guard that prevents deletion of user-created files).
-  testDeleteOrphanedFilesChecksOldState = {
-    expr = lib.strings.hasInfix "OVERRIDES_WAS_MANAGED" installWithDeleteOrphanedFiles.mkOverridesCmd;
-    expected = true;
-  };
-
-  # deleteOrphanedFiles=false must not generate any rm -f calls.
-  testDeleteOrphanedFilesDisabledHasNoRm = {
-    expr = lib.strings.hasInfix "rm -f" installWithoutDeleteOrphanedFiles.mkOverridesCmd;
-    expected = false;
-  };
-
-  # file never in old state must not be deleted.
-  testUnmanagedFileIsPreserved = {
-    expr = runDeleteOrphanedTest {
-      appId = "com.handcrafted.App";
-      oldStateJson = builtins.toJSON {
-        version = 2;
-        overrides = { settings = {}; files = []; };
-        packages = [];
-        remotes = [];
+    testLegacyFormatNewOverrideAdded = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides = {"com.example.app" = {"Context" = {"shared" = "ipc";};};};};
+        activeState = builtins.toJSON {};
       };
-      newStateJson = builtins.toJSON {
-        version = 2;
-        overrides = { settings = {}; files = []; };
-        packages = [];
-        remotes = [];
-      };
+      expected = "[Context]\nshared=ipc\n\n";
     };
-    expected = "exists";
-  };
 
-  # A file previously tracked in overrides.settings must be deleted
-  # when removed from the new state.
-  testPreviouslyManagedSettingsFileIsDeleted = {
-    expr = runDeleteOrphanedTest {
-      appId = "com.example.App";
-      oldStateJson = builtins.toJSON {
-        version = 2;
-        overrides = { settings = { "com.example.App" = { Context = { shared = "network"; }; }; }; files = []; };
-        packages = [];
-        remotes = [];
+    testLegacyFormatOverrideRemoved = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides = {"com.example.app" = {};};};
+        activeState = builtins.toJSON {"Context" = {"shared" = "network";};};
       };
-      newStateJson = builtins.toJSON {
-        version = 2;
-        overrides = { settings = {}; files = []; };
-        packages = [];
-        remotes = [];
-      };
+      expected = "[Context]\nshared=network\n\n";
     };
-    expected = "deleted";
-  };
 
-  # A file previously tracked via overrides.files must be deleted
-  # when removed from the new state.
-  testPreviouslyManagedOverridesFileIsDeleted = {
-    expr = runDeleteOrphanedTest {
-      appId = "com.file.App";
-      oldStateJson = builtins.toJSON {
-        version = 2;
-        overrides = { settings = {}; files = [ "/some/path/com.file.App" ]; };
-        packages = [];
-        remotes = [];
+    testLegacyFormatOverrideUpdated = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides = {"com.example.app" = {"Context" = {"shared" = "x11";};};};};
+        activeState = builtins.toJSON {"Context" = {"shared" = "network";};};
       };
-      newStateJson = builtins.toJSON {
-        version = 2;
-        overrides = { settings = {}; files = []; };
-        packages = [];
-        remotes = [];
-      };
+      expected = "[Context]\nshared=x11\n\n";
     };
-    expected = "deleted";
-  };
 
-  # A file still present in both old and new state must not be deleted.
-  testCurrentlyManagedFileIsPreserved = {
-    expr = runDeleteOrphanedTest {
-      appId = "com.example.App";
-      oldStateJson = builtins.toJSON {
-        version = 2;
-        overrides = { settings = { "com.example.App" = { Context = { shared = "network"; }; }; }; files = []; };
-        packages = [];
-        remotes = [];
+    testMixedFormatUpgrade = {
+      expr = runJqScript {
+        appId = "com.example.app";
+        newState = builtins.toJSON {overrides.settings = {"com.example.app" = {"Context" = {"shared" = "ipc";};};};};
+        activeState = builtins.toJSON {"Context" = {"shared" = "network";};};
       };
-      newStateJson = builtins.toJSON {
-        version = 2;
-        overrides = { settings = { "com.example.App" = { Context = { shared = "network"; }; }; }; files = []; };
-        packages = [];
-        remotes = [];
-      };
+      expected = "[Context]\nshared=ipc\n\n";
     };
-    expected = "exists";
-  };
 
-  # A file tracked in legacy-format old state must be deleted when removed.
-  testLegacyFormatManagedFileIsDeleted = {
-    expr = runDeleteOrphanedTest {
-      appId = "com.legacy.App";
-      oldStateJson = builtins.toJSON {
-        overrides = { "com.legacy.App" = { Context = { shared = "network"; }; }; };
-        packages = [];
-        remotes = [];
-      };
-      newStateJson = builtins.toJSON {
-        version = 2;
-        overrides = { settings = {}; files = []; };
-        packages = [];
-        remotes = [];
-      };
+    testReplaceModeHasCpCmd = {
+      expr = lib.strings.hasInfix "cp --no-preserve" installWithReplaceMode.mkOverridesCmd;
+      expected = true;
     };
-    expected = "deleted";
-  };
-}
+
+    testReplaceModeHasNoJcIni = {
+      expr = lib.strings.hasInfix "jc --ini" installWithReplaceMode.mkOverridesCmd;
+      expected = false;
+    };
+
+    testExplicitMergeModeHasJcIni = {
+      expr = lib.strings.hasInfix "jc --ini" installWithExplicitMergeMode.mkOverridesCmd;
+      expected = true;
+    };
+
+    testExplicitMergeModeHasNoCpCmd = {
+      expr = lib.strings.hasInfix "cp --no-preserve" installWithExplicitMergeMode.mkOverridesCmd;
+      expected = false;
+    };
+
+    testReplaceModeOverrideFilesNonEmpty = {
+      expr = builtins.length (builtins.attrNames installWithReplaceMode.replaceOverrideFiles) > 0;
+      expected = true;
+    };
+
+    testMergeModeReplaceOverrideFilesEmpty = {
+      expr = installWithExplicitMergeMode.replaceOverrideFiles == {};
+      expected = true;
+    };
+
+    testReplaceModeSettingsAppContent = {
+      expr = builtins.readFile installWithReplaceMode.replaceOverrideFiles."com.example.app";
+      expected = "[Context]\nshared=network\n";
+    };
+
+    testReplaceModeFileOnlyAppContent = {
+      expr = builtins.readFile installWithReplaceMode.replaceOverrideFiles."com.other.app";
+      expected = "[Context]\nshared=network\n";
+    };
+
+    testReplaceModeWithPruneChecksOldState = {
+      expr = lib.strings.hasInfix "OVERRIDES_WAS_MANAGED" installWithReplaceModeAndPrune.mkOverridesCmd;
+      expected = true;
+    };
+
+    testReplaceModeWithPruneHasRm = {
+      expr = lib.strings.hasInfix "rm -f" installWithReplaceModeAndPrune.mkOverridesCmd;
+      expected = true;
+    };
+
+    testReplaceModeWithoutPruneHasNoRm = {
+      expr = lib.strings.hasInfix "rm -f" installWithReplaceMode.mkOverridesCmd;
+      expected = false;
+    };
+
+    testPruneUnmanagedOverridesChecksOldState = {
+      expr = lib.strings.hasInfix "OVERRIDES_WAS_MANAGED" installWithPruneUnmanagedOverrides.mkOverridesCmd;
+      expected = true;
+    };
+
+    testPruneUnmanagedOverridesDisabledHasNoRm = {
+      expr = lib.strings.hasInfix "rm -f" installWithoutPruneUnmanagedOverrides.mkOverridesCmd;
+      expected = false;
+    };
+
+    testUnmanagedFileIsPreserved = {
+      expr = runDeleteOrphanedTest {
+        appId = "com.handcrafted.App";
+        oldStateJson = builtins.toJSON {
+          version = 2;
+          overrides = {
+            settings = {};
+            files = [];
+          };
+          packages = [];
+          remotes = [];
+        };
+        newStateJson = builtins.toJSON {
+          version = 2;
+          overrides = {
+            settings = {};
+            files = [];
+          };
+          packages = [];
+          remotes = [];
+        };
+      };
+      expected = "exists";
+    };
+
+    testPreviouslyManagedSettingsFileIsDeleted = {
+      expr = runDeleteOrphanedTest {
+        appId = "com.example.App";
+        oldStateJson = builtins.toJSON {
+          version = 2;
+          overrides = {
+            settings = {"com.example.App" = {Context = {shared = "network";};};};
+            files = [];
+          };
+          packages = [];
+          remotes = [];
+        };
+        newStateJson = builtins.toJSON {
+          version = 2;
+          overrides = {
+            settings = {};
+            files = [];
+          };
+          packages = [];
+          remotes = [];
+        };
+      };
+      expected = "deleted";
+    };
+
+    testPreviouslyManagedOverridesFileIsDeleted = {
+      expr = runDeleteOrphanedTest {
+        appId = "com.file.App";
+        oldStateJson = builtins.toJSON {
+          version = 2;
+          overrides = {
+            settings = {};
+            files = ["/some/path/com.file.App"];
+          };
+          packages = [];
+          remotes = [];
+        };
+        newStateJson = builtins.toJSON {
+          version = 2;
+          overrides = {
+            settings = {};
+            files = [];
+          };
+          packages = [];
+          remotes = [];
+        };
+      };
+      expected = "deleted";
+    };
+
+    testCurrentlyManagedFileIsPreserved = {
+      expr = runDeleteOrphanedTest {
+        appId = "com.example.App";
+        oldStateJson = builtins.toJSON {
+          version = 2;
+          overrides = {
+            settings = {"com.example.App" = {Context = {shared = "network";};};};
+            files = [];
+          };
+          packages = [];
+          remotes = [];
+        };
+        newStateJson = builtins.toJSON {
+          version = 2;
+          overrides = {
+            settings = {"com.example.App" = {Context = {shared = "network";};};};
+            files = [];
+          };
+          packages = [];
+          remotes = [];
+        };
+      };
+      expected = "exists";
+    };
+
+    testLegacyFormatManagedFileIsDeleted = {
+      expr = runDeleteOrphanedTest {
+        appId = "com.legacy.App";
+        oldStateJson = builtins.toJSON {
+          overrides = {"com.legacy.App" = {Context = {shared = "network";};};};
+          packages = [];
+          remotes = [];
+        };
+        newStateJson = builtins.toJSON {
+          version = 2;
+          overrides = {
+            settings = {};
+            files = [];
+          };
+          packages = [];
+          remotes = [];
+        };
+      };
+      expected = "deleted";
+    };
+
+    testFileSettingsManagedFileIsPreserved = {
+      expr = runDeleteOrphanedTest {
+        appId = "com.file.App";
+        oldStateJson = builtins.toJSON {
+          version = 2;
+          overrides = {
+            settings = {};
+            files = ["/some/path/com.file.App"];
+          };
+          packages = [];
+          remotes = [];
+        };
+        newStateJson = builtins.toJSON {
+          version = 2;
+          overrides = {
+            settings = {};
+            files = ["/some/path/com.file.App"];
+            _fileSettings."com.file.App" = {Context = {shared = "network";};};
+          };
+          packages = [];
+          remotes = [];
+        };
+      };
+      expected = "exists";
+    };
+
+    # Legacy-format old state + writeMode="replace": the prune block in flatpakOverridesReplaceCmd
+    # must contain the ($old.overrides[$app_id]) fallback so it correctly identifies apps that were
+    # managed in a legacy-format generation (where app configs sit directly on overrides without a
+    # .settings wrapper). Verified structurally: the jq expression is the same in both modes.
+    testReplaceModeWithPruneHandlesLegacyOldState = {
+      expr = lib.strings.hasInfix ''$old.overrides[$app_id]'' installWithReplaceModeAndPrune.mkOverridesCmd;
+      expected = true;
+    };
+  }

--- a/tests/state/overrides-test.nix
+++ b/tests/state/overrides-test.nix
@@ -3,6 +3,78 @@ let
   inherit (pkgs) lib;
   inherit (lib) runTests;
   jqScriptPath = ../../modules/flatpak/state/overrides.jq;
+
+  # Runs the orphan-deletion loop against a temporary overrides directory.
+  # Returns "exists" if `appId` is still present afterwards, "deleted" if not.
+  runDeleteOrphanedTest = { appId, oldStateJson, newStateJson, overrideFilesJson ? "{}" }:
+    builtins.readFile (pkgs.runCommand "delete-orphaned-${appId}" {
+      buildInputs = [ pkgs.jq pkgs.coreutils ];
+    } ''
+      OVERRIDES_DIR=$(mktemp -d)
+      touch "$OVERRIDES_DIR/${appId}"
+
+      OLD_STATE='${oldStateJson}'
+      NEW_STATE='${newStateJson}'
+
+      for OVERRIDE_FILE in "$OVERRIDES_DIR"/*; do
+        [[ -f "$OVERRIDE_FILE" ]] || continue
+        APP_ID=$(${pkgs.coreutils}/bin/basename "$OVERRIDE_FILE")
+
+        OVERRIDES_WAS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
+          --arg app_id "$APP_ID" \
+          --argjson old "$OLD_STATE" \
+          '(($old.overrides.settings[$app_id] // $old.overrides[$app_id]) != null) or
+           ($old.overrides.files // [] | map(split("/") | last) | index($app_id) != null)')
+
+        OVERRIDES_IS_MANAGED=$(${pkgs.jq}/bin/jq -r -n \
+          --arg app_id "$APP_ID" \
+          --argjson new "$NEW_STATE" \
+          --argjson override_files '${overrideFilesJson}' \
+          '(($new.overrides.settings[$app_id] // $new.overrides[$app_id]) != null) or
+           ($override_files[$app_id] != null)')
+
+        if [[ "$OVERRIDES_WAS_MANAGED" == "true" && "$OVERRIDES_IS_MANAGED" == "false" ]]; then
+          ${pkgs.coreutils}/bin/rm -f "$OVERRIDE_FILE"
+        fi
+      done
+
+      if [[ -f "$OVERRIDES_DIR/${appId}" ]]; then
+        echo -n "exists" > $out
+      else
+        echo -n "deleted" > $out
+      fi
+    '');
+
+  # install.nix instances for structural tests
+  installation = "user";
+  baseConfig = {
+    update = { onActivation = false; auto = { enable = false; }; };
+    remotes = [{ name = "some-remote"; location = "https://some.remote.tld/repo/test-remote.flatpakrepo"; }];
+    packages = [{ appId = "SomeAppId"; origin = "some-remote"; bundle = null; sha256 = null; }];
+    uninstallUnmanaged = false;
+    uninstallUnused = false;
+  };
+  installWithDeleteOrphanedFiles = import ../../modules/flatpak/install.nix {
+    cfg = baseConfig // {
+      overrides = {
+        settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; };
+        files = [ "/path/to/com.other.app" ];
+        deleteOrphanedFiles = true;
+      };
+    };
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
+  installWithoutDeleteOrphanedFiles = import ../../modules/flatpak/install.nix {
+    cfg = baseConfig // {
+      overrides = {
+        settings = { "com.example.app" = { "Context" = { "shared" = "network"; }; }; };
+      };
+    };
+    inherit pkgs lib installation;
+    executionContext = "service-start";
+  };
+
   runJqScript = { appId, oldState, newState, activeState, baseOverrides ? "{}", hasOverrideFile ? false, fileWasRemoved ? false }:
     let
       oldFile = pkgs.writeTextFile {
@@ -40,7 +112,6 @@ let
     builtins.toString output; # Preserve newline formatting for INI output
 in
 runTests {
-  # Original tests (should still pass)
   testNoChanges = {
     expr = runJqScript {
       appId = "com.example.app";
@@ -432,5 +503,120 @@ runTests {
       activeState = builtins.toJSON { "Context" = { "shared" = "network"; }; };
     };
     expected = "[Context]\nshared=ipc\n\n";
+  };
+
+
+  # deleteOrphanedFiles=true must generate a script containing OVERRIDES_WAS_MANAGED
+  # (the old-state guard that prevents deletion of user-created files).
+  testDeleteOrphanedFilesChecksOldState = {
+    expr = lib.strings.hasInfix "OVERRIDES_WAS_MANAGED" installWithDeleteOrphanedFiles.mkOverridesCmd;
+    expected = true;
+  };
+
+  # deleteOrphanedFiles=false must not generate any rm -f calls.
+  testDeleteOrphanedFilesDisabledHasNoRm = {
+    expr = lib.strings.hasInfix "rm -f" installWithoutDeleteOrphanedFiles.mkOverridesCmd;
+    expected = false;
+  };
+
+  # file never in old state must not be deleted.
+  testUnmanagedFileIsPreserved = {
+    expr = runDeleteOrphanedTest {
+      appId = "com.handcrafted.App";
+      oldStateJson = builtins.toJSON {
+        version = 2;
+        overrides = { settings = {}; files = []; };
+        packages = [];
+        remotes = [];
+      };
+      newStateJson = builtins.toJSON {
+        version = 2;
+        overrides = { settings = {}; files = []; };
+        packages = [];
+        remotes = [];
+      };
+    };
+    expected = "exists";
+  };
+
+  # A file previously tracked in overrides.settings must be deleted
+  # when removed from the new state.
+  testPreviouslyManagedSettingsFileIsDeleted = {
+    expr = runDeleteOrphanedTest {
+      appId = "com.example.App";
+      oldStateJson = builtins.toJSON {
+        version = 2;
+        overrides = { settings = { "com.example.App" = { Context = { shared = "network"; }; }; }; files = []; };
+        packages = [];
+        remotes = [];
+      };
+      newStateJson = builtins.toJSON {
+        version = 2;
+        overrides = { settings = {}; files = []; };
+        packages = [];
+        remotes = [];
+      };
+    };
+    expected = "deleted";
+  };
+
+  # A file previously tracked via overrides.files must be deleted
+  # when removed from the new state.
+  testPreviouslyManagedOverridesFileIsDeleted = {
+    expr = runDeleteOrphanedTest {
+      appId = "com.file.App";
+      oldStateJson = builtins.toJSON {
+        version = 2;
+        overrides = { settings = {}; files = [ "/some/path/com.file.App" ]; };
+        packages = [];
+        remotes = [];
+      };
+      newStateJson = builtins.toJSON {
+        version = 2;
+        overrides = { settings = {}; files = []; };
+        packages = [];
+        remotes = [];
+      };
+    };
+    expected = "deleted";
+  };
+
+  # A file still present in both old and new state must not be deleted.
+  testCurrentlyManagedFileIsPreserved = {
+    expr = runDeleteOrphanedTest {
+      appId = "com.example.App";
+      oldStateJson = builtins.toJSON {
+        version = 2;
+        overrides = { settings = { "com.example.App" = { Context = { shared = "network"; }; }; }; files = []; };
+        packages = [];
+        remotes = [];
+      };
+      newStateJson = builtins.toJSON {
+        version = 2;
+        overrides = { settings = { "com.example.App" = { Context = { shared = "network"; }; }; }; files = []; };
+        packages = [];
+        remotes = [];
+      };
+    };
+    expected = "exists";
+  };
+
+  # A file tracked in legacy-format old state must be deleted when removed.
+  testLegacyFormatManagedFileIsDeleted = {
+    expr = runDeleteOrphanedTest {
+      appId = "com.legacy.App";
+      oldStateJson = builtins.toJSON {
+        overrides = { "com.legacy.App" = { Context = { shared = "network"; }; }; };
+        packages = [];
+        remotes = [];
+      };
+      newStateJson = builtins.toJSON {
+        version = 2;
+        overrides = { settings = {}; files = []; };
+        packages = [];
+        remotes = [];
+      };
+    };
+    expected = "deleted";
   };
 }


### PR DESCRIPTION
Addresses #82 , #128.

## Why
From #82:

_[...] I have a number of Flatpak override config files already present on my device. It would be very useful if I could simply drop them in a folder as part of my OS config. This would also allow users to use tools they are already familiar with, when configuring Flatpak overrides, e.g. flatseal, and the built in configuration tool present on KDE. [...]_


## What
This PR introduces the capability to read overrides from user provided config files, and perform a three way merge with `config.flatpak.overrides` and the active state config. It refactors the `overrides` attrset adds four new keys:
* `settings`: nix attrser keyed by app id. It's values are Flatpak overrides.
* `files`: list of override files in Flatapak in ini format. Paths outside of nix store will require an impure evaluation.
* `pruneUnmanagedOverrides`: controls how override files that are removed from configuration will be deleted 
from the flatpak overrides directory.
* `writeMode`:  controls how Nix-managed override settings are written to the Flatpak overrides directory.

## How

The `overrides` config has been refactored with two new options:
 - `settings`: an attribute set of override settings
 - `files`: a list of paths to ini Flatpak overrides files. The files will be merged with the settings attribute set.

At activation `nix-flatpak` will merge override configurations from multiple sources:
- `base`: base configuration from override files (`config.flatpak.overrides.files`).
- `active`: currently active overrides (existing state. e.g. `$HOME/.local/share/flatpak/overrides`).
- `old_state`: previous declarative state (e.g. `$HOME/.local/state/home-manager/gcroots/flatpak-state.json`).
- `new_state`: new declarative state (e.g. `config.flatpak.overrides.settings`).

For each entry, the merge formula is:
 ```
 base + (active - old) + new
 ```
 
 ## Example
 ```
   services.flatpak.overrides.settings =  {
    global = {
      # Force Wayland by default
      Context.sockets = ["wayland" "!x11" "!fallback-x11"];

      Environment = {
        # Fix un-themed cursor in some Wayland apps
        XCURSOR_PATH = "/run/host/user-share/icons:/run/host/share/icons";

        # Force correct theme for some GTK apps
        GTK_THEME = "Adwaita:dark";
      };
    };

    "com.visualstudio.code".Context = {
      filesystems = [
        "xdg-config/git:ro" # Expose user Git config
        "/run/current-system/sw/bin:ro" # Expose NixOS managed software
      ];
      sockets = [
        "gpg-agent" # Expose GPG agent
        "pcsc" # Expose smart cards (i.e. YubiKey)
      ];
    };
  };

  services.flatpak.overrides.files = [
    "/home/gmodena/config/overrides/org.onlyoffice.desktopeditors"
    "/home/gmodena/config/overrides/org.gnome.gedit"
    "/home/gmodena/config/overrides/global"
  ];
 ```

Where the the override files looks like the following:
```
$ cat /home/gmodena/config/overrides/org.onlyoffice.desktopeditors
[Context]
sockets=x11

$ cat /home/gmodena/config/overrides/org.gnome.gedit
[Context]
sockets=wayland;!x11;fallback-x11;

$ cat /home/gmodena/config/overrides/global
[Environment]
LC_ALL = "C.UTF-8"
```

