### PR TITLE
install: simplify package update logic.

### DIFF
--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -269,8 +269,7 @@ let
             fi
           '';
       in
-      if update then installAndUpdatePinnedCmd
-      else determineFlatpakStateChange;
+      determineFlatpakStateChange;
 
 
   flatpakInstall = installation: update: packages: map (flatpakInstallCmd installation update) packages;

--- a/tests/update-on-activation-test.nix
+++ b/tests/update-on-activation-test.nix
@@ -60,6 +60,37 @@ fi
     # invoke the installer from a timer, when update.auto is enabled but update.onActivation is disabled.
     # Packages will be updated.
     expr = timerExecutionContext.mkInstallCmd;
-    expected = "${pkgs.flatpak}/bin/flatpak --system --noninteractive install --or-update some-remote SomeAppId\n\n";
+    expected = ''if false; then
+    # Check if sha256 changed between OLD_STATE and NEW_STATE
+    changedSha256="$(${pkgs.jq}/bin/jq -ns \
+      --argjson oldState "$OLD_STATE" \
+      --argjson newState "$NEW_STATE" \
+      --arg appId "SomeAppId" \
+      -f ${../modules/flatpak/state/compare_sha.jq})"
+
+    if [[ -n "$changedSha256" ]]; then
+      if ${pkgs.flatpak}/bin/flatpak --system info "SomeAppId" &>/dev/null; then
+        ${pkgs.flatpak}/bin/flatpak --system uninstall -y "SomeAppId"
+        : # No operation if no install command needs to run.
+      fi
+      
+      : # No operation if no install command needs to run.
+    fi
+else
+  # Check if app exists in old state, handling both formats
+  if $( ${pkgs.jq}/bin/jq -r -n --argjson old "$OLD_STATE" --arg appId "SomeAppId" --from-file ${../modules/flatpak/state/app_exists.jq} | ${pkgs.gnugrep}/bin/grep -q true ); then
+    # App exists in old state, check if commit changed
+    if [[ -n "" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --system info "SomeAppId" --show-commit 2>/dev/null )" != "" ]]; then
+      
+      : # No operation if no install command needs to run.
+    fi
+  else
+    ${pkgs.flatpak}/bin/flatpak --system --noninteractive install --or-update some-remote SomeAppId
+
+
+    : # No operation if no install command needs to run.
+  fi
+fi
+'';
   };
 }

--- a/tests/update-on-timer-test.nix
+++ b/tests/update-on-timer-test.nix
@@ -4,19 +4,44 @@ let
   inherit (lib) runTests;
   installation = "system";
   flatpakConfig = import ./config.nix;
-  cfg = flatpakConfig // {
+  
+  # Configuration for service-start context (no updates on activation)
+  serviceStartCfg = flatpakConfig // {
     update = flatpakConfig.update // {
       auto = {
         enable = true;
       };
+      onActivation = false;  # This is key - disable updates on activation
     };
-    # Add the missing packages configuration
     packages = [
       { appId = "SomeAppId"; origin = "some-remote"; }
     ];
   };
-  timerExecutionContext = import ../modules/flatpak/install.nix { inherit cfg pkgs lib installation; executionContext = "timer"; };
-  serviceStartExecutionContext = import ../modules/flatpak/install.nix { inherit cfg pkgs lib installation; executionContext = "service-start"; };
+  
+  # Configuration for timer context (allows updates)
+  timerCfg = flatpakConfig // {
+    update = flatpakConfig.update // {
+      auto = {
+        enable = true;
+      };
+      onActivation = true;   # Enable updates for timer context
+    };
+    packages = [
+      { appId = "SomeAppId"; origin = "some-remote"; }
+    ];
+  };
+  
+  timerExecutionContext = import ../modules/flatpak/install.nix { 
+    cfg = timerCfg; 
+    inherit pkgs lib installation; 
+    executionContext = "timer"; 
+  };
+  
+  serviceStartExecutionContext = import ../modules/flatpak/install.nix { 
+    cfg = serviceStartCfg; 
+    inherit pkgs lib installation; 
+    executionContext = "service-start"; 
+  };
 in
 runTests {
   testDoNotUpdate = {
@@ -60,6 +85,37 @@ fi
     # invoke the installer from a timer, when update.auto is enabled but update.onActivation is disabled.
     # Packages will be updated.
     expr = timerExecutionContext.mkInstallCmd;
-    expected = "${pkgs.flatpak}/bin/flatpak --system --noninteractive install --or-update some-remote SomeAppId\n\n";
+    expected = ''if false; then
+    # Check if sha256 changed between OLD_STATE and NEW_STATE
+    changedSha256="$(${pkgs.jq}/bin/jq -ns \
+      --argjson oldState "$OLD_STATE" \
+      --argjson newState "$NEW_STATE" \
+      --arg appId "SomeAppId" \
+      -f ${../modules/flatpak/state/compare_sha.jq})"
+
+    if [[ -n "$changedSha256" ]]; then
+      if ${pkgs.flatpak}/bin/flatpak --system info "SomeAppId" &>/dev/null; then
+        ${pkgs.flatpak}/bin/flatpak --system uninstall -y "SomeAppId"
+        : # No operation if no install command needs to run.
+      fi
+      
+      : # No operation if no install command needs to run.
+    fi
+else
+  # Check if app exists in old state, handling both formats
+  if $( ${pkgs.jq}/bin/jq -r -n --argjson old "$OLD_STATE" --arg appId "SomeAppId" --from-file ${../modules/flatpak/state/app_exists.jq} | ${pkgs.gnugrep}/bin/grep -q true ); then
+    # App exists in old state, check if commit changed
+    if [[ -n "" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --system info "SomeAppId" --show-commit 2>/dev/null )" != "" ]]; then
+      
+      : # No operation if no install command needs to run.
+    fi
+  else
+    ${pkgs.flatpak}/bin/flatpak --system --noninteractive install --or-update some-remote SomeAppId
+
+
+    : # No operation if no install command needs to run.
+  fi
+fi
+'';
   };
 }


### PR DESCRIPTION
Remove redundant test on update triggers
and delegate the install/update command generation logic to `determineFlatpakStateChange`.

Fixes a bug that caused bundle installation to fail when auto-update was enabled.

Part of #135 