### PR TITLE
flatpak: install: fix update regression

### DIFF
--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -261,6 +261,9 @@ let
                 if [[ -n "${safeCommit}" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --${installation} info "${resolvedAppId}" --show-commit 2>/dev/null )" != "${safeCommit}" ]]; then
                   ${updatePinnedCmd}
                   : # No operation if no install command needs to run.
+                elif ${if update then "true" else "false"}; then
+                  ${installAndUpdatePinnedCmd}
+                  : # No operation if no install command needs to run.
                 fi
               else
                 ${installAndUpdatePinnedCmd}

--- a/tests/idempotent-install-test.nix
+++ b/tests/idempotent-install-test.nix
@@ -49,6 +49,16 @@ else
     if [[ -n "abc123" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --user info "org.gnome.gedit" --show-commit 2>/dev/null )" != "abc123" ]]; then
       ${pkgs.flatpak}/bin/flatpak --user --noninteractive update --commit="abc123" org.gnome.gedit
       : # No operation if no install command needs to run.
+    elif false; then
+      ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  $(if ${pkgs.flatpak}/bin/flatpak --user list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q org.gnome.gedit; then
+    echo "gedit-origin org.gnome.gedit"
+else
+    echo "--from ${flatpakrefUrl}"
+fi)
+
+${pkgs.flatpak}/bin/flatpak --user --noninteractive update --commit="abc123" org.gnome.gedit
+
+      : # No operation if no install command needs to run.
     fi
   else
     ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  $(if ${pkgs.flatpak}/bin/flatpak --user list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q org.gnome.gedit; then
@@ -84,6 +94,11 @@ else
     # App exists in old state, check if commit changed
     if [[ -n "" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --user info "SomeAppId" --show-commit 2>/dev/null )" != "" ]]; then
       
+      : # No operation if no install command needs to run.
+    elif false; then
+      ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  some-remote SomeAppId
+
+
       : # No operation if no install command needs to run.
     fi
   else

--- a/tests/install-from-file-test.nix
+++ b/tests/install-from-file-test.nix
@@ -44,6 +44,11 @@ else
     if [[ -n "" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --user info "noop" --show-commit 2>/dev/null )" != "" ]]; then
       
       : # No operation if no install command needs to run.
+    elif false; then
+      
+
+
+      : # No operation if no install command needs to run.
     fi
   else
     

--- a/tests/update-on-activation-test.nix
+++ b/tests/update-on-activation-test.nix
@@ -46,6 +46,11 @@ else
     if [[ -n "" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --system info "SomeAppId" --show-commit 2>/dev/null )" != "" ]]; then
       
       : # No operation if no install command needs to run.
+    elif false; then
+      ${pkgs.flatpak}/bin/flatpak --system --noninteractive install  some-remote SomeAppId
+
+
+      : # No operation if no install command needs to run.
     fi
   else
     ${pkgs.flatpak}/bin/flatpak --system --noninteractive install  some-remote SomeAppId
@@ -82,6 +87,11 @@ else
     # App exists in old state, check if commit changed
     if [[ -n "" ]] && [[ "$( ${pkgs.flatpak}/bin/flatpak --system info "SomeAppId" --show-commit 2>/dev/null )" != "" ]]; then
       
+      : # No operation if no install command needs to run.
+    elif true; then
+      ${pkgs.flatpak}/bin/flatpak --system --noninteractive install --or-update some-remote SomeAppId
+
+
       : # No operation if no install command needs to run.
     fi
   else


### PR DESCRIPTION
Execute `flatpak install --or-update ...` if
the application is present in the old nix-flatpak
state (e.g. it's installed and managed by us), and on activation or scheduled updates are enabled.

Fixes a regression introduced in #163.

Bug: #165 