### PR TITLE
systemd: Use binary path from home-manager

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,5 +1,6 @@
 { config, lib, pkgs, ... }@args:
 let
+  inherit (config.systemd.user) systemctlPath;
   helpers = import ./common.nix { inherit lib config; };
   cfg = helpers.warnDeprecated config.services.flatpak;
   installation = "user";
@@ -45,10 +46,8 @@ in
 
     home.activation = {
       flatpak-managed-install = lib.hm.dag.entryAfter [ "reloadSystemd" ] ''
-        export PATH=${lib.makeBinPath (with pkgs; [ systemd ])}:$PATH
-
-        $DRY_RUN_CMD systemctl is-system-running -q && \
-          systemctl --user start flatpak-managed-install.service || true
+        $DRY_RUN_CMD ${systemctlPath} is-system-running -q && \
+          ${systemctlPath} --user start flatpak-managed-install.service || true
       '';
     };
 


### PR DESCRIPTION
Using `config.systemd.user.systemctlPath` instead of `pkgs.systemd` improves compaibility with non-NixOS installations of home-manager. In particular, this allows removing Nix's systemd from the output closure to use the host's instead.