### PR TITLE
remove usage of mkDoc (fails when evaluated)

### DIFF
--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -11,7 +11,7 @@ in
     enable = with lib; mkOption {
       type = types.bool;
       default = args.osConfig.services.flatpak.enable or false;
-      description = mkDoc "Whether to enable nix-flatpak declarative flatpak management in home-manager.";
+      description = "Whether to enable nix-flatpak declarative flatpak management in home-manager.";
     };
   };
 


### PR DESCRIPTION
Hi! Thank you for maintaining this project

I was setting up [optnix](https://github.com/water-sucks/optnix), which evaluates all modules and finds option definitions. And then I got an error during evaluation that mkDoc does not exist.

Looking into it, mkDoc seems to be a transitional marker of docs that haven't transitioned to markdown, and mdDoc is transitioned. But both mkDoc and mdDoc have been removed already - [mdDoc in 24.11's release notes](https://github.com/NixOS/nixpkgs/blob/865f635c17957952f72c7ec77d185e59d69c1dab/nixos/doc/manual/release-notes/rl-2411.section.md?plain=1#L1028). And [mdDoc is a no-op](https://github.com/NixOS/nixpkgs/pull/303841).

TLDR: mkDoc doesn't exist anymore and the only necessary change is removing the call to it