### PR TITLE
flake: add Hjem module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,5 +5,6 @@
     {
       nixosModules = { nix-flatpak = ./modules/nixos.nix; };
       homeManagerModules = { nix-flatpak = ./modules/home-manager.nix; };
+      hjemModules = { nix-flatpak = ./modules/hjem.nix; };
     };
 }

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -1,4 +1,4 @@
-{ lib, config }:
+{ lib }:
 rec {
   mkExponentialBackoff = cfg:
     if cfg.restartOnFailure.exponentialBackoff.enable then {

--- a/modules/hjem.nix
+++ b/modules/hjem.nix
@@ -1,0 +1,34 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  helpers = import ./common.nix { inherit lib; };
+  cfg = helpers.warnDeprecated config.services.flatpak;
+  installation = "user";
+in
+{
+  options.services.flatpak = (import ./options.nix { inherit config lib pkgs; }) // {
+    enable = lib.mkEnableOption "nix-flatpak";
+  };
+  config = lib.mkIf cfg.enable {
+    systemd = {
+      services."flatpak-managed-install" = {
+        after = [ "multi-user.target" ];
+        wantedBy = [ "default.target" ];
+        serviceConfig =
+          helpers.mkCommonServiceConfig {
+            inherit cfg pkgs lib installation ;
+            executionContext = "service-start";
+          }
+          // helpers.mkRestartOptions cfg;
+      };
+      timers."flatpak-managed-install-timer" = lib.mkIf cfg.update.auto.enable {
+        wantedBy = [ "timers.target" ];
+        timerConfig = helpers.mkCommonTimerConfig cfg;
+      };
+    };
+  };
+}

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }@args:
 let
   inherit (config.systemd.user) systemctlPath;
-  helpers = import ./common.nix { inherit lib config; };
+  helpers = import ./common.nix { inherit lib; };
   cfg = helpers.warnDeprecated config.services.flatpak;
   installation = "user";
 in

--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 let
-  helpers = import ./common.nix { inherit lib config; };
+  helpers = import ./common.nix { inherit lib; };
   cfg = helpers.warnDeprecated config.services.flatpak;
   installation = "system";
 in

--- a/testing-base/flake.lock
+++ b/testing-base/flake.lock
@@ -11,6 +11,27 @@
       },
       "parent": []
     },
+    "hjem": {
+      "inputs": {
+        "nix-darwin": [],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777061801,
+        "narHash": "sha256-a0O56qWfPEKe0mBKgvcQL5UDpWmon70AKJspHNkEJV8=",
+        "owner": "feel-co",
+        "repo": "hjem",
+        "rev": "35c2158ba101d7b42b05debfcb169ba32dad3bbc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "feel-co",
+        "repo": "hjem",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -51,6 +72,7 @@
     "root": {
       "inputs": {
         "flatpaks": "flatpaks",
+        "hjem": "hjem",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs"
       }

--- a/testing-base/flake.nix
+++ b/testing-base/flake.nix
@@ -4,9 +4,12 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     home-manager.url = "github:nix-community/home-manager/release-25.11";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    hjem.url = "github:feel-co/hjem";
+    hjem.inputs.nixpkgs.follows = "nixpkgs";
+    hjem.inputs.nix-darwin.follows = "";
     flatpaks.url = "../";
   };
-  outputs = inputs@{ self, nixpkgs, home-manager, flatpaks, ... }:
+  outputs = inputs@{ nixpkgs, home-manager, hjem, flatpaks, ... }:
     let
       system = "x86_64-linux";
     in
@@ -37,6 +40,24 @@
             home-manager.users.antani.home.stateVersion = "23.11";
           }
           ./configuration.nix
+        ];
+      };
+
+      # hostname = test-hjem-module
+      nixosConfigurations.test-hjem-module = nixpkgs.lib.nixosSystem {
+        inherit system;
+        module = [
+          hjem.nixosModules.default
+          ./configuration.nix
+          {
+            config.hjem = {
+              extraModules = [
+                flatpaks.hjmeModules.flatpak
+                ./flatpak.nix
+              ];
+              users.alice.services.flatpak.enable = true;
+            };
+          }
         ];
       };
     };


### PR DESCRIPTION
Add a `nix-flatpak` module for [Hjem](https://github.com/feel-co/hjem).

The options live under `config.hjem.users.<user>.services.flatpak`. 