### PR TITLE
fix: remove nonfunctional null byte escape

### DIFF
--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -199,7 +199,7 @@
     # string literals. Reject these at evaluation time so they never reach the
     # generated shell script.
     # TODO(gmodena, 2026-04): this list is expected to grow.
-    invalidChars = ["\n" "\r" "\x00" "'"];
+    invalidChars = ["\n" "\r" "'"];
     hasInvalidChar = path: builtins.any (c: lib.strings.hasInfix c path) invalidChars;
     invalidPaths = builtins.filter hasInvalidChar files;
   in

--- a/tests/state/legacy-overrides-test.nix
+++ b/tests/state/legacy-overrides-test.nix
@@ -287,26 +287,6 @@ in
       };
     };
 
-    testPathWithNullByteThrows = {
-      expr = builtins.tryEval (
-        (import ../../modules/flatpak/install.nix {
-          cfg =
-            baseConfig
-            // {
-              overrides = {
-                files = ["/path/to/com.example\x00app"];
-              };
-            };
-          inherit pkgs lib installation;
-          executionContext = "service-start";
-        }).mkSaveStateCmd
-      );
-      expected = {
-        success = false;
-        value = false;
-      };
-    };
-
     testWriteModeMergeEvaluates = {
       expr = builtins.isString installWriteModeMerge.mkOverridesCmd;
       expected = true;


### PR DESCRIPTION
using lix with version string `nix (Lix, like Nix) 2.95.1` there is a warning about incorrect escape:
```
warning: \x is an ill-defined escape. You can drop the \ and simply write x instead. Use --extra-deprecated-features broken-string-escape to silence this warning.
         at <snip>/modules/flatpak/install.nix:202:33:
            201|     # TODO(gmodena, 2026-04): this list is expected to grow.
            202|     invalidChars = ["\n" "\r" "\x00" "'"];
```
Per my understanding, this escape also does not work properly with nix, but lix is the only implementation with a warning enabled for invalid escapes.

I looked into how to properly represent a null byte in a nix string, and found https://github.com/NixOS/nix/issues/1307 .

It seems that there is no way to represent a null byte in a nix string, so I just deleted it from the list.