### PR TITLE
fix: improve flatpakref handling robustness

### DIFF
--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -118,7 +118,7 @@
     appId = flatpakrefCache.${(utils.sanitizeUrl flatpakrefUrl)}.Name;
     origin = utils.getRemoteNameFromFlatpakref null flatpakrefCache.${(utils.sanitizeUrl flatpakrefUrl)};
   in ''
-    $(if ${pkgs.flatpak}/bin/flatpak --${installation} list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q ${appId}; then
+    $(if ${pkgs.flatpak}/bin/flatpak --${installation} list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q "^${appId}$"; then
         echo "${origin} ${appId}"
     else
         echo "--from ${flatpakrefUrl}"

--- a/modules/flatpak/ref.nix
+++ b/modules/flatpak/ref.nix
@@ -69,7 +69,7 @@ let
             parsed = builtins.filter (line: line != null) (map (line: builtins.match "(.*)=(.*)" (builtins.toString line)) lines);
 
             # Convert the list of key-value pairs into an attrset
-            attrSet = builtins.listToAttrs (map (pair: { name = builtins.elemAt pair 0; value = builtins.elemAt pair 1; }) parsed);
+            attrSet = builtins.listToAttrs (map (pair: { name = lib.strings.trim (builtins.elemAt pair 0); value = lib.strings.trim (builtins.elemAt pair 1); }) parsed);
           in
           cache // { ${(sanitizeUrl flatpakref)} = attrSet; };
     in

--- a/tests/fixtures/spaced.flatpakref
+++ b/tests/fixtures/spaced.flatpakref
@@ -1,0 +1,6 @@
+[Flatpak Ref]
+Name = test.demo.App
+Branch = test.branch
+Title = Test App With Spaces
+SuggestRemoteName = test-remote
+Url = https://example.com/flatpak/repo/

--- a/tests/idempotent-install-test.nix
+++ b/tests/idempotent-install-test.nix
@@ -50,7 +50,7 @@ else
       ${pkgs.flatpak}/bin/flatpak --user --noninteractive update --commit="abc123" org.gnome.gedit
       : # No operation if no install command needs to run.
     elif false; then
-      ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  $(if ${pkgs.flatpak}/bin/flatpak --user list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q org.gnome.gedit; then
+      ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  $(if ${pkgs.flatpak}/bin/flatpak --user list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q "^org.gnome.gedit$"; then
     echo "gedit-origin org.gnome.gedit"
 else
     echo "--from ${flatpakrefUrl}"
@@ -61,7 +61,7 @@ ${pkgs.flatpak}/bin/flatpak --user --noninteractive update --commit="abc123" org
       : # No operation if no install command needs to run.
     fi
   else
-    ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  $(if ${pkgs.flatpak}/bin/flatpak --user list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q org.gnome.gedit; then
+    ${pkgs.flatpak}/bin/flatpak --user --noninteractive install  $(if ${pkgs.flatpak}/bin/flatpak --user list --app --columns=application | ${pkgs.gnugrep}/bin/grep -q "^org.gnome.gedit$"; then
     echo "gedit-origin org.gnome.gedit"
 else
     echo "--from ${flatpakrefUrl}"

--- a/tests/ref-test.nix
+++ b/tests/ref-test.nix
@@ -19,6 +19,16 @@ let
       DeployCollectionID = "org.gnome.Apps";
     };
   };
+  spacedFixturePath = "file://${pwd}/fixtures/spaced.flatpakref";
+  expectedSpacedFixtureAttrSet = {
+    ${ref.sanitizeUrl spacedFixturePath} = {
+      Name = "test.demo.App";
+      Branch = "test.branch";
+      Title = "Test App With Spaces";
+      SuggestRemoteName = "test-remote";
+      Url = "https://example.com/flatpak/repo/";
+    };
+  };
 in
 runTests {
   testSanitizeUrl = {
@@ -74,5 +84,10 @@ runTests {
   testFlatpakrefToAttrSetWithSha256 = {
     expr = ref.flatpakrefToAttrSet { flatpakref = fixturePath; sha256 = fixtureHash; } { };
     expected = expectedFixtureAttrSet;
+  };
+
+  testFlatpakrefToAttrSetWithSpaces = {
+    expr = ref.flatpakrefToAttrSet { flatpakref = spacedFixturePath; sha256 = null; } { };
+    expected = expectedSpacedFixtureAttrSet;
   };
 }


### PR DESCRIPTION
This PR fixes two common issues with flatpakref processing:

1. Trim whitespace for ini-style flatpakref parsing
The original ini parser didn't clean up leading/trailing whitespace around
key-value pairs, which caused parsing failures for flatpakref files that
use spaces around `=`, triggering:
`error: attribute 'Name' missing`

2. Use exact match to check installed app
The original check used substring grep matching, which was easily triggered
by sub-packages (such as Locale/Debug packages) or residual install states,
leading to wrong mode switch to remote install, and caused error:
`No such ref 'app/xxx/x86_64/xxx' in remote`