### PR TITLE
fix: installing from user and system remotes on the same system when they have names other than "flathub"

### DIFF
--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -66,7 +66,7 @@
         origin =
           if utils.isFlatpakref package
           then utils.getRemoteNameFromFlatpakref null flatpakrefCache.${utils.sanitizeUrl package.flatpakref}
-          else package.origin ? cfg.defaultRemote;
+          else package.origin ? cfg.defaultOrigin;
       in {
         appId = appId;
         origin = origin;
@@ -381,7 +381,7 @@
 
   flatpakInstallCmd = installation: update: {
     appId,
-    origin ? cfg.defaultRemote,
+    origin ? cfg.defaultOrigin,
     commit ? null,
     flatpakref ? null,
     bundle ? null,

--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -66,7 +66,7 @@
         origin =
           if utils.isFlatpakref package
           then utils.getRemoteNameFromFlatpakref null flatpakrefCache.${utils.sanitizeUrl package.flatpakref}
-          else package.origin;
+          else package.origin ? cfg.defaultRemote;
       in {
         appId = appId;
         origin = origin;
@@ -381,7 +381,7 @@
 
   flatpakInstallCmd = installation: update: {
     appId,
-    origin ? "flathub",
+    origin ? cfg.defaultRemote,
     commit ? null,
     flatpakref ? null,
     bundle ? null,

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -45,8 +45,8 @@ with lib; let
 
       origin = mkOption {
         type = types.str;
-        default = "flathub";
-        description = "App repository origin (default: flathub).";
+        default = config.services.flatpak.defaultRemote;
+        description = "App repository origin.";
       };
 
       flatpakref = mkOption {
@@ -276,6 +276,12 @@ in {
       # Flathub is the default initialized by this flake.
       [{ name = "flathub"; location = "https://dl.flathub.org/repo/flathub.flatpakrepo"; }]
     '';
+  };
+
+  defaultRemote = mkOption {
+    type = types.str;
+    description = "Default repo to install flatpak(s) from.";
+    default = "flathub";
   };
 
   overrides = mkOption {

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -45,8 +45,8 @@ with lib; let
 
       origin = mkOption {
         type = types.str;
-        default = config.services.flatpak.defaultRemote;
-        description = "App repository origin.";
+        default = config.services.flatpak.defaultOrigin;
+        description = "App repository origin. (default: Flathub)";
       };
 
       flatpakref = mkOption {

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -46,7 +46,7 @@ with lib; let
       origin = mkOption {
         type = types.str;
         default = config.services.flatpak.defaultOrigin;
-        description = "App repository origin. (default: Flathub)";
+        description = "App repository origin. (default: flathub)";
       };
 
       flatpakref = mkOption {

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -278,7 +278,7 @@ in {
     '';
   };
 
-  defaultRemote = mkOption {
+  defaultOrigin = mkOption {
     type = types.str;
     description = "Default repo to install flatpak(s) from.";
     default = "flathub";


### PR DESCRIPTION
add a `defaultRemote` option to specify which origin flatpaks should come from if one is not explicitly given (i.e. only an appID is provided). Used as below (example config for Home Manager):

```nix
{ ... }:
{
  services.flatpak = {
    # define some remotes
    remotes = [
      {
        name = "flathub-user";
        location = "https://dl.flathub.org/repo/flathub.flatpakrepo";
      }
      {
        name = "flathub-user-beta";
        location = "https://flathub.org/beta-repo/flathub-beta.flatpakrepo";
      }
    ];
    
    # `defaultRemote` itself defaults to "flathub", change it to "flathub-user"
    defaultRemote = "flathub-user";

    packages = [ 
      # will come from `defaultRemote` (i.e. "flathub-user")
      "org.mozilla.Thunderbird"

      # can still explicitly provide origin for specific packages
      {
        origin = "flathub-user-beta";
        appId = "org.kde.sweeper";
      }
    ];
  };
}
```

Maybe this would be better renamed `defaultOrigin` to follow how is named in the existing `packages` section?

@gmodena #201