### PR TITLE
fix: make state file default origin evaluate to str, not bool

### DIFF
--- a/modules/flatpak/install.nix
+++ b/modules/flatpak/install.nix
@@ -66,7 +66,7 @@
         origin =
           if utils.isFlatpakref package
           then utils.getRemoteNameFromFlatpakref null flatpakrefCache.${utils.sanitizeUrl package.flatpakref}
-          else package.origin ? cfg.defaultOrigin;
+          else package.origin or cfg.defaultOrigin;
       in {
         appId = appId;
         origin = origin;


### PR DESCRIPTION
770055e3a6a484f88e36302da5b2a910f6a4528b introduced the line in question, but
used the `?` operator instead of `or`. In this context the value evaluates to
whether the attributes `cfg.defaultOrigin` exist in `package.origin` rather than
defaulting to `cfg.defaultOrigin` if `package.origin` is not present. `?` only
works as a "default"/"or" operator in function parameter declarations, but as a
"has attribute(s)" operator everywhere else.

- <https://nix.dev/manual/nix/2.34/language/operators.html#has-attribute>
- <https://nix.dev/manual/nix/2.34/language/syntax#functions>

@gmodena
