### PR TITLE
WIP: coercedTo from-type causing overrides sub-option type errors

### DIFF
--- a/modules/options.nix
+++ b/modules/options.nix
@@ -290,8 +290,8 @@ in {
     # always receives a consistent submodule value.
     type = with types;
       coercedTo
-      (addCheck (attrsOf (attrsOf (attrsOf (either str (listOf str)))))
-        (v: !(v ? settings || v ? files || v ? pruneUnmanagedOverrides)))
+      (addCheck attrs
+        (v: !(v ? settings || v ? files || v ? pruneUnmanagedOverrides || v ? writeMode)))
       (legacySettings: {settings = legacySettings;})
       (submodule overridesOptions);
     default = {};


### PR DESCRIPTION
Why:

coercedTo with attrsOf as the from-type caused the module system to validate
submodule keys against the attrsOf element type instead of the submodule's
declared option types making `pruneUnmanagedOverrides = true` fail as
"not of type attrsOf (attrsOf ...)"

What:

Change the from-type to plain `attrs` (isAttrs only).

Bug: #205 